### PR TITLE
add api to add/get secure cookie; use secure cookie to do the xsrf valid...

### DIFF
--- a/config.go
+++ b/config.go
@@ -48,6 +48,7 @@ var (
 	CopyRequestBody      bool //When in raw application, You want to the reqeustbody
 	TemplateLeft         string
 	TemplateRight        string
+	SecureKey            string //cookie secure hash key
 )
 
 func init() {
@@ -82,6 +83,7 @@ func init() {
 	TemplateRight = "}}"
 	ParseConfig()
 	runtime.GOMAXPROCS(runtime.NumCPU())
+	SecureKey = "beegocookiesecure!@#$%^&*()"
 }
 
 func ParseConfig() (err error) {
@@ -172,6 +174,9 @@ func ParseConfig() (err error) {
 		}
 		if keyfile := AppConfig.String("HttpKeyFile"); keyfile != "" {
 			HttpKeyFile = keyfile
+		}
+		if securekey := AppConfig.String("SecureKey"); securekey != "" {
+			SecureKey = securekey
 		}
 	}
 	return nil

--- a/context/context.go
+++ b/context/context.go
@@ -1,7 +1,16 @@
 package context
 
 import (
+	"bytes"
+	"crypto/hmac"
+	"crypto/sha1"
+	"encoding/base64"
+	"fmt"
+	"io/ioutil"
 	"net/http"
+	"strconv"
+	"strings"
+	"time"
 )
 
 type Context struct {
@@ -9,6 +18,7 @@ type Context struct {
 	Output         *BeegoOutput
 	Request        *http.Request
 	ResponseWriter http.ResponseWriter
+	SecureKey      string
 }
 
 func (ctx *Context) Redirect(status int, localurl string) {
@@ -31,4 +41,62 @@ func (ctx *Context) GetCookie(key string) string {
 
 func (ctx *Context) SetCookie(name string, value string, others ...interface{}) {
 	ctx.Output.Cookie(name, value, others...)
+}
+
+//code is migrated from [Go web](https://github.com/hoisie/web/blob/master/web.go)
+//all rights are reserved by @hoisie
+func getCookieSig(key string, val []byte, timestamp string) string {
+	hm := hmac.New(sha1.New, []byte(key))
+
+	hm.Write(val)
+	hm.Write([]byte(timestamp))
+
+	hex := fmt.Sprintf("%02x", hm.Sum(nil))
+	return hex
+}
+
+//code is migrated from [Go web](https://github.com/hoisie/web/blob/master/web.go)
+//all rights are reserved by @hoisie
+func (ctx *Context) GetSecureCookie(key string) string {
+	if cookie := ctx.GetCookie(key); cookie != "" {
+		parts := strings.SplitN(cookie, "|", 3)
+
+		val := parts[0]
+		timestamp := parts[1]
+		sig := parts[2]
+
+		if getCookieSig(ctx.SecureKey, []byte(val), timestamp) != sig {
+			return ""
+		}
+
+		ts, _ := strconv.ParseInt(timestamp, 0, 64)
+
+		if time.Now().Unix()-31*86400 > ts {
+			return ""
+		}
+
+		buf := bytes.NewBufferString(val)
+		encoder := base64.NewDecoder(base64.StdEncoding, buf)
+
+		res, _ := ioutil.ReadAll(encoder)
+		return string(res)
+	}
+
+	return ""
+}
+
+//code is migrated from [Go web](https://github.com/hoisie/web/blob/master/web.go)
+//all rights are reserved by @hoisie
+func (ctx *Context) SetSecureCookie(name string, val string, others ...interface{}) {
+	var buf bytes.Buffer
+	encoder := base64.NewEncoder(base64.StdEncoding, &buf)
+	encoder.Write([]byte(val))
+	encoder.Close()
+	vs := buf.String()
+	vb := buf.Bytes()
+	timestamp := strconv.FormatInt(time.Now().Unix(), 10)
+	sig := getCookieSig(ctx.SecureKey, vb, timestamp)
+	cookie := strings.Join([]string{vs, timestamp, sig}, "|")
+
+	ctx.Output.Cookie(name, cookie, others...)
 }

--- a/controller.go
+++ b/controller.go
@@ -306,7 +306,7 @@ func (c *Controller) IsAjax() bool {
 
 func (c *Controller) XsrfToken() string {
 	if c._xsrf_token == "" {
-		token := c.Ctx.GetCookie("_xsrf")
+		token := c.Ctx.GetSecureCookie("_xsrf")
 		if token == "" {
 			h := hmac.New(sha1.New, []byte(XSRFKEY))
 			fmt.Fprintf(h, "%s:%d", c.Ctx.Request.RemoteAddr, time.Now().UnixNano())
@@ -318,7 +318,7 @@ func (c *Controller) XsrfToken() string {
 			} else {
 				expire = XSRFExpire
 			}
-			c.Ctx.SetCookie("_xsrf", token, expire, "/")
+			c.Ctx.SetSecureCookie("_xsrf", token, expire, "/")
 		}
 		c._xsrf_token = token
 	}

--- a/router.go
+++ b/router.go
@@ -298,6 +298,7 @@ func (p *ControllerRegistor) ServeHTTP(rw http.ResponseWriter, r *http.Request) 
 		Request:        r,
 		Input:          beecontext.NewInput(r),
 		Output:         beecontext.NewOutput(w),
+		SecureKey:      SecureKey,
 	}
 	context.Output.Context = context
 


### PR DESCRIPTION
Changes:
1. Add GetSecureCookie and SetSecureCookie to context/context.go
2. Change the _xsrf validation to use the secured cookie

Tested pass on our environment.
