### PR TITLE
Update config.go

### DIFF
--- a/config.go
+++ b/config.go
@@ -53,7 +53,7 @@ var (
 func init() {
 	os.Chdir(path.Dir(os.Args[0]))
 	BeeApp = NewApp()
-	AppPath, _ = os.Getwd()
+	AppPath, _ = path.Dir(os.Args[0])
 	StaticDir = make(map[string]string)
 	TemplateCache = make(map[string]*template.Template)
 	HttpAddr = ""


### PR DESCRIPTION
将AppPath, _ = os.Getwd()
改为AppPath, _ = path.Dir(os.Args[0])

如果beego作为服务运行的话，在windows下得到的目录是c:\windows\system32
