### PR TITLE
minor fix,if path does not include ':', beego will crash of "index out of range"

### DIFF
--- a/config.go
+++ b/config.go
@@ -185,7 +185,7 @@ func ParseConfig() (err error) {
 			}
 			sds := strings.Fields(sd)
 			for _, v := range sds {
-				if url2fsmap := strings.SplitN(v, ":", 2); url2fsmap[1] != "" {
+				if url2fsmap := strings.SplitN(v, ":", 2); len(url2fsmap) == 2 {
 					StaticDir["/"+url2fsmap[0]] = url2fsmap[1]
 				} else {
 					StaticDir["/"+url2fsmap[0]] = url2fsmap[0]


### PR DESCRIPTION
如果StaticPath里的某个field里没有:就会引起beego的crash。所以增加了len的判断。
