### PR TITLE
[orm] QueryTable with nil ptr struct

### DIFF
--- a/orm/orm.go
+++ b/orm/orm.go
@@ -274,9 +274,7 @@ func (o *orm) QueryTable(ptrStructOrTableName interface{}) (qs QuerySeter) {
 			qs = newQuerySet(o, mi)
 		}
 	} else {
-		val := reflect.ValueOf(ptrStructOrTableName)
-		ind := reflect.Indirect(val)
-		name = getFullName(ind.Type())
+		name = getFullName(indirectType(reflect.TypeOf(ptrStructOrTableName)))
 		if mi, ok := modelCache.getByFN(name); ok {
 			qs = newQuerySet(o, mi)
 		}

--- a/orm/orm_test.go
+++ b/orm/orm_test.go
@@ -473,6 +473,7 @@ The program—and web server—godoc processes Go source files to extract docume
 func TestExpr(t *testing.T) {
 	user := &User{}
 	qs := dORM.QueryTable(user)
+	qs = dORM.QueryTable((*User)(nil))
 	qs = dORM.QueryTable("User")
 	qs = dORM.QueryTable("user")
 	num, err := qs.Filter("UserName", "slene").Filter("user_name", "slene").Filter("profile__Age", 28).Count()

--- a/orm/utils.go
+++ b/orm/utils.go
@@ -231,3 +231,13 @@ func timeParse(dateString, format string) (time.Time, error) {
 func timeFormat(t time.Time, format string) string {
 	return t.Format(format)
 }
+
+func indirectType(v reflect.Type) reflect.Type {
+	switch v.Kind() {
+	case reflect.Ptr:
+		return indirectType(v.Elem())
+	default:
+		return v
+	}
+	return v
+}


### PR DESCRIPTION
下面的代码会 panic:

```
qs = dORM.QueryTable((*User)(nil))
```

使用`(*User)(nil)`形式可以减少一个malloc
