### PR TITLE
add server host:port info when starting app

### DIFF
--- a/app.go
+++ b/app.go
@@ -28,10 +28,14 @@ func (app *App) Run() {
 	if HttpPort != 0 {
 		addr = fmt.Sprintf("%s:%d", HttpAddr, HttpPort)
 	}
+
+	BeeLogger.Info("Runing on %s", addr)
+
 	var (
 		err error
 		l   net.Listener
 	)
+
 	if UseFcgi {
 		if HttpPort == 0 {
 			l, err = net.Listen("unix", addr)
@@ -72,6 +76,7 @@ func (app *App) Run() {
 			}
 		}
 	}
+
 	if err != nil {
 		BeeLogger.Critical("ListenAndServe: ", err)
 		time.Sleep(100 * time.Microsecond)


### PR DESCRIPTION
Add server host:port information when starting app, otherwise we need to check the configuration file to get the right host:port.
