### PR TITLE
remove duplicated config initialization

### DIFF
--- a/config.go
+++ b/config.go
@@ -104,7 +104,7 @@ func ParseConfig() (err error) {
 	if err != nil {
 		return err
 	} else {
-		HttpAddr = AppConfig.String("httpaddr")
+		HttpAddr = AppConfig.String("HttpAddr")
 
 		if v, err := AppConfig.Int("HttpPort"); err == nil {
 			HttpPort = v


### PR DESCRIPTION
ini format configuration now supports case insensitive keys, so we can remove the duplicated lines in beego/config.go 
