### PR TITLE
Improve unhandled error handling in prod mode

### DIFF
--- a/router.go
+++ b/router.go
@@ -368,8 +368,8 @@ func (p *ControllerRegistor) ServeHTTP(rw http.ResponseWriter, r *http.Request) 
 			if _, ok := err.(middleware.HTTPException); ok {
 				// catch intented errors, only for HTTP 4XX and 5XX
 			} else {
-				errstr := fmt.Sprint(err)
-				if handler, ok := middleware.ErrorMaps[errstr]; ok && ErrorsShow {
+				handler := p.getErrorHandler(fmt.Sprint(err))
+				if ErrorsShow {
 					handler(rw, r)
 				} else {
 					if !RecoverPanic {
@@ -863,6 +863,24 @@ Admin:
 			}
 		}
 	}
+}
+
+// there always should be error handler that sets error code accordingly for all unhandled errors
+// in order to have custom UI for error page it's necessary to override "500" error
+func (p *ControllerRegistor) getErrorHandler(errorCode string) func(rw http.ResponseWriter, r *http.Request) {
+	handler := middleware.SimpleServerError
+	ok := true
+	if errorCode != "" {
+		handler, ok = middleware.ErrorMaps[errorCode]
+		if !ok {
+			handler, ok = middleware.ErrorMaps["500"]
+		}
+		if !ok || handler == nil {
+			handler = middleware.SimpleServerError
+		}
+	}
+
+	return handler
 }
 
 //responseWriter is a wrapper for the http.ResponseWriter


### PR DESCRIPTION
In case of unhandled error in Prod mode beego returns 200 status code which is not correct. It's better to return 500 error code in case of unhandled exception. It's also possible to override error 500 and have custom UI for that.
