### PR TITLE
修复支持svg文件 mimetype

### DIFF
--- a/mime.go
+++ b/mime.go
@@ -401,7 +401,7 @@ var mimemaps map[string]string = map[string]string{
 	"sv4cpio":     "application/x-sv4cpio",
 	"sv4crc":      "application/x-sv4crc",
 	"svf":         "image/vnddwg",
-	"svg":         "image/svg+xml",
+	"svg":         "image/svg-xml",
 	"svr":         "application/x-world",
 	"swf":         "application/x-shockwave-flash",
 	"t":           "application/x-troff",


### PR DESCRIPTION
使用中，发现需要支持.svg文件，一开始发现不支持.svg 随后在代码中发现这个，并修改了
