### PR TITLE
repaired the wrong IP when using in localhost (Mac os x)

### DIFF
--- a/context/input.go
+++ b/context/input.go
@@ -98,7 +98,9 @@ func (input *BeegoInput) IP() string {
 	}
 	ip := strings.Split(input.Request.RemoteAddr, ":")
 	if len(ip) > 0 {
-		return ip[0]
+		if ip[0] != "["{
+			return ip[0]
+		}
 	}
 	return "127.0.0.1"
 }


### PR DESCRIPTION
it returns “[“ when using beego in local host(Mac os x 10.9) , it
appears that Request.remoAddr returns “[::1]:57944”
