### PR TITLE
diffrent level logs display diffrent color

### DIFF
--- a/logs/console.go
+++ b/logs/console.go
@@ -6,6 +6,25 @@ import (
 	"os"
 )
 
+type Brush func(string) string
+
+func NewBrush(color string) Brush {
+	pre := "\033["
+	reset := "\033[0m"
+	return func(text string) string {
+		return pre + color + "m" + text + reset
+	}
+}
+
+var colors = []Brush{
+	NewBrush("1;36"), // Trace      cyan
+	NewBrush("1;34"), // Debug      blue
+	NewBrush("1;32"), // Info       green
+	NewBrush("1;33"), // Warn       yellow
+	NewBrush("1;31"), // Error      red
+	NewBrush("1;35"), // Critical   purple
+}
+
 // ConsoleWriter implements LoggerInterface and writes messages to terminal.
 type ConsoleWriter struct {
 	lg    *log.Logger
@@ -35,7 +54,7 @@ func (c *ConsoleWriter) WriteMsg(msg string, level int) error {
 	if level < c.Level {
 		return nil
 	}
-	c.lg.Println(msg)
+	c.lg.Println(colors[level](msg))
 	return nil
 }
 


### PR DESCRIPTION
对不同级别的日志在终端可以显示为不用的颜色，这里仅仅是对日志显示的内容进行的颜色转换，但是对日志本身的时间前缀没有做颜色转换。在这里讨论一下是否需要对时间前缀也做相应的颜色转换。
