### PR TITLE
[orm] Add a Debug method to allow for debugging individual queries.

### DIFF
--- a/orm/orm.go
+++ b/orm/orm.go
@@ -445,6 +445,16 @@ func (o *orm) GetDB() dbQuerier {
 	return o.db
 }
 
+// return a copy of the orm instance with Debug enabled
+func (o orm) Debug() Ormer {
+	// The receiver type of this is intentially a Value and *not*
+	// a pointer in order to take advantage of Go's call by Value
+	// semantics, causing "o" to get copied. As such, Debug is only
+	// enabled for the Value returned by this method call.
+	o.db = newDbQueryLog(o.alias, o.db)
+	return &o
+}
+
 // create new orm
 func NewOrm() Ormer {
 	BootStrap() // execute only once

--- a/orm/types.go
+++ b/orm/types.go
@@ -38,6 +38,7 @@ type Ormer interface {
 	Raw(string, ...interface{}) RawSeter
 	Driver() Driver
 	GetDB() dbQuerier
+	Debug() Ormer
 }
 
 // insert prepared statement


### PR DESCRIPTION
Hi! I have another addition for you to consider. I was looking for an easy to be able to debug individual queries without turning debug on globally. Let me know if there's a better way to accomplish this. Here's what I've come up with:

o := NewOrm()
u := &User{Name: "Kyle"}
o.Read(user, "Name") // logs nothing

u2 := &User{Email: "kylemcc@gmail.com"}
o.Debug().Read(u2, "Email") // logs debug query: SELECT `id`, `name`, `email` FROM `user` WHERE `email` = "kylemcc@gmail.com";

qs := o.Debug().QueryTable("users")
qs.Filter("Profile__Id", 10).One(u) // also logs debug query
