### PR TITLE
Update captcha.go

### DIFF
--- a/utils/captcha/captcha.go
+++ b/utils/captcha/captcha.go
@@ -175,14 +175,14 @@ func (c *Captcha) CreateCaptcha() (string, error) {
 }
 
 // verify from a request
-func (c *Captcha) VerifyReq(req *http.Request) bool {
+func (c *Captcha) VerifyReq(req *http.Request, alwaysDelete bool) bool {
 	req.ParseForm()
-	return c.Verify(req.Form.Get(c.FieldIdName), req.Form.Get(c.FieldCaptchaName))
+	return c.Verify(req.Form.Get(c.FieldIdName), req.Form.Get(c.FieldCaptchaName), alwaysDelete)
 }
 
 // direct verify id and challenge string
-func (c *Captcha) Verify(id string, challenge string) (success bool) {
-	if len(challenge) == 0 || len(id) == 0 {
+func (c *Captcha) Verify(id string, challenge string, alwaysDelete bool) (success bool) {
+	if (!alwaysDelete && len(challenge) == 0) || len(id) == 0 {
 		return
 	}
 
@@ -192,6 +192,9 @@ func (c *Captcha) Verify(id string, challenge string) (success bool) {
 
 	if v, ok := c.store.Get(key).([]byte); ok && len(v) == len(challenge) {
 		chars = v
+	} else if ok && alwaysDelete {
+		c.store.Delete(key)
+		return
 	} else {
 		return
 	}


### PR DESCRIPTION
This is to allow us to Always delete the key when `Verify()` was **FALSE** and that we can then call `NewCaptcha()` again.
