### PR TITLE
fix: added nil check on c.CruSession to prevent crash

### DIFF
--- a/controller.go
+++ b/controller.go
@@ -397,7 +397,9 @@ func (c *Controller) DelSession(name interface{}) {
 // SessionRegenerateID regenerates session id for this session.
 // the session data have no changes.
 func (c *Controller) SessionRegenerateID() {
-	c.CruSession.SessionRelease(c.Ctx.ResponseWriter)
+	if c.CruSession != nil {
+		c.CruSession.SessionRelease(c.Ctx.ResponseWriter)
+	}
 	c.CruSession = GlobalSessions.SessionRegenerateId(c.Ctx.ResponseWriter, c.Ctx.Request)
 	c.Ctx.Input.CruSession = c.CruSession
 }


### PR DESCRIPTION
Howdy!

Specs: 
OSX 10.9.2
Go 1.2
Beego 1.1.0

Problem:
After upgrading to beego 1.x, my application was broken. After many hours of troubleshooting I ruled out any errors with my code. I then started to investigate the beego source code and found the following change.

https://github.com/astaxie/beego/commit/6e9ba0ea7f014642f62a915d28e6868cd41f1474#diff-e30be89bfd41a0c219178028b9971a32

I realized that when calling SessionRegenerateID() no check is preformed on c.CruSession to validate that the struct is actually instantiated. This can cause your application to crash.

Validate:
$ bee new bugtest
$ cd bugtest
$ vi controllers/default.go

``` go
 func (this *MainController) Get() {
  this.Data["Website"] = "beego.me"
  this.Data["Email"] = "astaxie@gmail.com"
  this.TplNames = "index.tpl"
  // add this line
  this.SessionRegenerateID()
}
```

$ bee run
$ wget http://localhost:8080 

"bugtest:runtime error: invalid memory address or nil pointer dereference"

14-02-26 04:08:16 [INFO] Uses 'beetest' as 'appname'
14-02-26 04:08:16 [INFO] Initializing watcher...
14-02-26 04:08:16 [TRAC] Directory(/Users/jfolkins/go/src/beetest/controllers)
14-02-26 04:08:16 [TRAC] Directory(/Users/jfolkins/go/src/beetest/models)
14-02-26 04:08:16 [TRAC] Directory(/Users/jfolkins/go/src/beetest)
14-02-26 04:08:16 [INFO] Start building...
14-02-26 04:08:17 [SUCC] Build was successful
14-02-26 04:08:17 [INFO] Restarting beetest ...
14-02-26 04:08:17 [INFO] ./beetest is running...
2014/02/26 16:08:17 [I] Running on :8080
2014/02/26 16:08:27 [C] the request url is  / 
2014/02/26 16:08:27 [C] Handler crashed with error runtime error: invalid memory address or nil pointer dereference 
2014/02/26 16:08:27 [C] /usr/local/Cellar/go/1.2/libexec/src/pkg/runtime/panic.c 248 
2014/02/26 16:08:27 [C] /usr/local/Cellar/go/1.2/libexec/src/pkg/runtime/panic.c 482 
2014/02/26 16:08:27 [C] /usr/local/Cellar/go/1.2/libexec/src/pkg/runtime/os_darwin.c 450 
2014/02/26 16:08:27 [C] /Users/jfolkins/go/src/github.com/astaxie/beego/controller.go 400 
2014/02/26 16:08:27 [C] /Users/jfolkins/go/src/beetest/controllers/default.go 15 
2014/02/26 16:08:27 [C] /Users/jfolkins/go/src/github.com/astaxie/beego/router.go 768 
2014/02/26 16:08:27 [C] /usr/local/Cellar/go/1.2/libexec/src/pkg/net/http/server.go 1597 
2014/02/26 16:08:27 [C] /usr/local/Cellar/go/1.2/libexec/src/pkg/net/http/server.go 1167 
2014/02/26 16:08:27 [C] /usr/local/Cellar/go/1.2/libexec/src/pkg/runtime/proc.c 1394 
