### PR TITLE
Fix basic auth plugin example.

### DIFF
--- a/plugins/auth/basic.go
+++ b/plugins/auth/basic.go
@@ -8,7 +8,7 @@ package auth
 // 	}
 // 	return false
 // }
-// authPlugin := auth.NewBasicAuthenticator(SecretAuth)
+// authPlugin := auth.NewBasicAuthenticator(SecretAuth, "My Realm")
 // beego.AddFilter("*","AfterStatic",authPlugin)
 
 import (


### PR DESCRIPTION
NewBasicAuthenticator requires passing a second argument for Realm.
