### PR TITLE
Enhancement: Allow developer to set FlashName and FlashSeperator values

### DIFF
--- a/config.go
+++ b/config.go
@@ -58,6 +58,8 @@ var (
 	EnableAdmin            bool   // flag of enable admin module to log every request info.
 	AdminHttpAddr          string // http server configurations for admin module.
 	AdminHttpPort          int
+	FlashName              string // name of the flash variable found in response header and cookie
+	FlashSeperator         string // used to seperate flash key:value
 )
 
 func init() {
@@ -122,6 +124,9 @@ func init() {
 	EnableAdmin = false
 	AdminHttpAddr = "127.0.0.1"
 	AdminHttpPort = 8088
+
+	FlashName = "BEEGO_FLASH"
+	FlashSeperator = "BEEGOFLASH"
 
 	runtime.GOMAXPROCS(runtime.NumCPU())
 
@@ -269,6 +274,14 @@ func ParseConfig() (err error) {
 
 		if serverName := AppConfig.String("BeegoServerName"); serverName != "" {
 			BeegoServerName = serverName
+		}
+
+		if flashname := AppConfig.String("FlashName"); flashname != "" {
+			FlashName = flashname
+		}
+
+		if flashseperator := AppConfig.String("FlashSeperator"); flashseperator != "" {
+			FlashSeperator = flashseperator
 		}
 
 		if sd := AppConfig.String("StaticDir"); sd != "" {

--- a/flash.go
+++ b/flash.go
@@ -3,21 +3,21 @@ package beego
 import (
 	"fmt"
 	"net/url"
-	"strings"
 )
-
-// the separation string when encoding flash data.
-const BEEGO_FLASH_SEP = "#BEEGOFLASH#"
 
 // FlashData is a tools to maintain data when using across request.
 type FlashData struct {
-	Data map[string]string
+	Data      map[string]string
+	Name      string
+	Seperator string
 }
 
 // NewFlash return a new empty FlashData struct.
 func NewFlash() *FlashData {
 	return &FlashData{
-		Data: make(map[string]string),
+		Data:      make(map[string]string),
+		Name:      FlashName,
+		Seperator: FlashSeperator,
 	}
 }
 
@@ -54,30 +54,7 @@ func (fd *FlashData) Store(c *Controller) {
 	c.Data["flash"] = fd.Data
 	var flashValue string
 	for key, value := range fd.Data {
-		flashValue += "\x00" + key + BEEGO_FLASH_SEP + value + "\x00"
+		flashValue += "\x00" + key + "\x23" + fd.Seperator + "\x23" + value + "\x00"
 	}
-	c.Ctx.SetCookie("BEEGO_FLASH", url.QueryEscape(flashValue), 0, "/")
-}
-
-// ReadFromRequest parsed flash data from encoded values in cookie.
-func ReadFromRequest(c *Controller) *FlashData {
-	flash := &FlashData{
-		Data: make(map[string]string),
-	}
-	if cookie, err := c.Ctx.Request.Cookie("BEEGO_FLASH"); err == nil {
-		v, _ := url.QueryUnescape(cookie.Value)
-		vals := strings.Split(v, "\x00")
-		for _, v := range vals {
-			if len(v) > 0 {
-				kv := strings.Split(v, BEEGO_FLASH_SEP)
-				if len(kv) == 2 {
-					flash.Data[kv[0]] = kv[1]
-				}
-			}
-		}
-		//read one time then delete it
-		c.Ctx.SetCookie("BEEGO_FLASH", "", -1, "/")
-	}
-	c.Data["flash"] = flash.Data
-	return flash
+	c.Ctx.SetCookie(fd.Name, url.QueryEscape(flashValue), 0, "/")
 }


### PR DESCRIPTION
Hello @Astaxie,

When building an application, there was a requirement for me not to leak what type of framework was being used. I made a patch that allows the user to set the Flash values in the .conf file or the main.go, so as not to indicate that beego was being used.

This is just a first purposal to see if you are open to the change. If I need to modify something let me know.

``` go
func main() {
  beego.Router("/", &controllers.MainController{})
  beego.FlashName = "CUSTOM_FLASH_NAME"
  beego.FlashSeperator = "CUSTOM_FLASH_SEPERATOR"
  beego.Run()
}
```

Thanks,
Jared
