### PR TITLE
Update router.go

### DIFF
--- a/router.go
+++ b/router.go
@@ -44,6 +44,11 @@ var (
 		"GetControllerAndAction"}
 )
 
+// To append a slice's value into "exceptMethod", for controller's methods shouldn't reflect to AutoRouter
+func ExceptMethodAppend(action string) {
+	exceptMethod = append(exceptMethod, action)
+}
+
 type controllerInfo struct {
 	pattern        string
 	regex          *regexp.Regexp


### PR DESCRIPTION
首先，表示抱歉的是我刚学会用git，还不是很会。另外我的英语水平不是很好，只能用Chinese了。

添加这个方法的目的是遇到了这么一个场景：
当在我的项目实例中，我的项目本身需要一个基础的控制器父类struct---实际是对beego框架默认控制器（“父类”）进行嵌套封装，我的项目本身的控制器父类struct也会定义了一些默认的methods，而这些methods有时候也是不希望暴露给路由分发的。

所以，我是希望在限制方面能够做到更加灵活，方便框架的实例应用。
