### PR TITLE
Update beego.go - Slice types exist trap

### DIFF
--- a/beego.go
+++ b/beego.go
@@ -28,12 +28,12 @@ type GroupRouters []groupRouter
 
 // Get a new GroupRouters
 func NewGroupRouters() GroupRouters {
-	return make([]groupRouter, 0)
+	return make(GroupRouters, 0)
 }
 
 // Add Router in the GroupRouters
 // it is for plugin or module to register router
-func (gr GroupRouters) AddRouter(pattern string, c ControllerInterface, mappingMethod ...string) {
+func (gr *GroupRouters) AddRouter(pattern string, c ControllerInterface, mappingMethod ...string) {
 	var newRG groupRouter
 	if len(mappingMethod) > 0 {
 		newRG = groupRouter{
@@ -48,16 +48,16 @@ func (gr GroupRouters) AddRouter(pattern string, c ControllerInterface, mappingM
 			"",
 		}
 	}
-	gr = append(gr, newRG)
+	*gr = append(*gr, newRG)
 }
 
-func (gr GroupRouters) AddAuto(c ControllerInterface) {
+func (gr *GroupRouters) AddAuto(c ControllerInterface) {
 	newRG := groupRouter{
 		"",
 		c,
 		"",
 	}
-	gr = append(gr, newRG)
+	*gr = append(*gr, newRG)
 }
 
 // AddGroupRouter with the prefix


### PR DESCRIPTION
Modify the file beego.go. 
Type GroupRouters all function 
Slice types exist trap bug.
