### PR TITLE
Update orm.go

### DIFF
--- a/orm/orm.go
+++ b/orm/orm.go
@@ -334,7 +334,9 @@ func (o *orm) getRelQs(md interface{}, mi *modelInfo, fi *fieldInfo) *querySet {
 	if fi.fieldType == RelManyToMany {
 		q.cond = q.cond.And(fi.reverseFieldInfoM2M.column+ExprSep+fi.reverseFieldInfo.column, md)
 	} else {
-		q.cond = q.cond.And(fi.reverseFieldInfo.column, md)
+		if fi.reverseFieldInfo != nil {
+			q.cond = q.cond.And(fi.reverseFieldInfo.column, md)
+		}
 	}
 
 	return q


### PR DESCRIPTION
This change is required to prevent crash for the following struct when trying to `LoadRelated` **ToUser**:

```
type FriendRequest struct {
    Id       int64     `orm:"pk;auto"`
    FromUser *AuthUser `orm:"rel(fk)"`
    ToUser   *AuthUser `orm:"rel(fk)"`
    Accepted bool
    Rejected bool

    Created time.Time `orm:"auto_now_add"`
    Updated time.Time `orm:"auto_now"`
}
```

Even by using rel(one) for both also crashes.
