### PR TITLE
[orm] allow unexported fields on model structs

### DIFF
--- a/orm/models_info_m.go
+++ b/orm/models_info_m.go
@@ -43,6 +43,9 @@ func newModelInfo(val reflect.Value) (info *modelInfo) {
 	for i := 0; i < ind.NumField(); i++ {
 		field := ind.Field(i)
 		sf = ind.Type().Field(i)
+		if sf.PkgPath != "" {
+			continue
+		}
 		fi, err = newFieldInfo(info, field, sf)
 
 		if err != nil {


### PR DESCRIPTION
Currently, calling orm.RegisterModel with a struct containing unexported fields causes a crash. This fixes that.
