### PR TITLE
httplib support to set the protocol version for incoming requests

### DIFF
--- a/httplib/README.md
+++ b/httplib/README.md
@@ -60,3 +60,8 @@ some http request need setcookie. So set it like this:
 	cookie.Value  = "astaxie"
 	httplib.Get("http://beego.me/").SetCookie(cookie)
 
+## set HTTP version
+some servers need to specify the protocol version of HTTP
+
+	httplib.Get("http://beego.me/").SetProtocolVersion("HTTP/1.1")
+	

--- a/httplib/httplib.go
+++ b/httplib/httplib.go
@@ -101,6 +101,23 @@ func (b *BeegoHttpRequest) Header(key, value string) *BeegoHttpRequest {
 	return b
 }
 
+// Set the protocol version for incoming requests.
+// Client requests always use HTTP/1.1.
+func (b *BeegoHttpRequest) SetProtocolVersion(vers string) *BeegoHttpRequest {
+	if len(vers) == 0 {
+		vers = "HTTP/1.1"
+	}
+
+	major, minor, ok := http.ParseHTTPVersion(vers)
+	if ok {
+		b.req.Proto = vers
+		b.req.ProtoMajor = major
+		b.req.ProtoMinor = minor
+	}
+
+	return b
+}
+
 // SetCookie add cookie into request.
 func (b *BeegoHttpRequest) SetCookie(cookie *http.Cookie) *BeegoHttpRequest {
 	b.req.Header.Add("Cookie", cookie.String())


### PR DESCRIPTION
At present, httplib do not set the protocol version for incoming requests, so the version always is "HTTP/0.0".
But some servers need to specify the protocol version, maybe is "HTTP/1.1" or others.
