### PR TITLE
config: fix error when json config starts with an array

### DIFF
--- a/config/json.go
+++ b/config/json.go
@@ -35,7 +35,12 @@ func (js *JsonConfig) Parse(filename string) (ConfigContainer, error) {
 	}
 	err = json.Unmarshal(content, &x.data)
 	if err != nil {
-		return nil, err
+		var wrappingArray []interface{}
+		err2 := json.Unmarshal(content, &wrappingArray)
+		if err2 != nil {
+			return nil, err
+		}
+		x.data["rootArray"] = wrappingArray
 	}
 	return x, nil
 }

--- a/config/json_test.go
+++ b/config/json_test.go
@@ -33,6 +33,53 @@ var jsoncontext = `{
     }
 }`
 
+var jsoncontextwitharray = `[
+	{
+		"url": "user",
+		"serviceAPI": "http://www.test.com/user"
+	},
+	{
+		"url": "employee",
+		"serviceAPI": "http://www.test.com/employee"
+	}
+]`
+
+func TestJsonStartsWithArray(t *testing.T) {
+	f, err := os.Create("testjsonWithArray.conf")
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = f.WriteString(jsoncontextwitharray)
+	if err != nil {
+		f.Close()
+		t.Fatal(err)
+	}
+	f.Close()
+	defer os.Remove("testjsonWithArray.conf")
+	jsonconf, err := NewConfig("json", "testjsonWithArray.conf")
+	if err != nil {
+		t.Fatal(err)
+	}
+	rootArray, err := jsonconf.DIY("rootArray")
+	if (err != nil) {
+		t.Error("array does not exist as element")
+	}
+	rootArrayCasted := rootArray.([]interface{})
+	if (rootArrayCasted == nil) {
+		t.Error("array from root is nil")
+	}else {
+		elem := rootArrayCasted[0].(map[string]interface{})
+		if elem["url"] != "user" || elem["serviceAPI"] != "http://www.test.com/user" {
+			t.Error("array[0] values are not valid")
+		}
+
+		elem2 := rootArrayCasted[1].(map[string]interface{})
+		if elem2["url"] != "employee" || elem2["serviceAPI"] != "http://www.test.com/employee" {
+			t.Error("array[1] values are not valid")
+		}
+	}
+}
+
 func TestJson(t *testing.T) {
 	f, err := os.Create("testjson.conf")
 	if err != nil {


### PR DESCRIPTION
[Bugfix] In case a json config has an array as root (which is valid json) the following error happened while trying to Unmarshal in the Parse-method:
json: cannot unmarshal array into Go value of type map[string]interface {}=== RUN TestJson

I added a few lines to prevent this error. In case Unmarshal gives back an err, it tries to Unmarshal as [] interface{} instead of map[string] interface{}.
- If this fails too, err from the **first** Unmarshal attempt is returned.
- If it is successful (= root is an array), the array is stored in the value "rootArray" in order to not violate other methods. The array can be accessed by calling DIY("rootArray") on the resulting config (to be added to docs).

A testcase is added using a json-file starting with an array as root
