### PR TITLE
beego/context: Fix ignored Header in case SetStatus has been called before

### DIFF
--- a/context/output.go
+++ b/context/output.go
@@ -71,6 +71,14 @@ func (output *BeegoOutput) Body(content []byte) {
 	} else {
 		output.Header("Content-Length", strconv.Itoa(len(content)))
 	}
+
+	// Write status code if it has been set manually
+	// Set it to 0 afterwards to prevent "multiple response.WriteHeader calls"
+	if output.Status != 0 {
+		output.Context.ResponseWriter.WriteHeader(output.Status)
+		output.Status = 0
+	}
+
 	output_writer.Write(content)
 	switch output_writer.(type) {
 	case *gzip.Writer:
@@ -270,7 +278,6 @@ func (output *BeegoOutput) ContentType(ext string) {
 // SetStatus sets response status code.
 // It writes response header directly.
 func (output *BeegoOutput) SetStatus(status int) {
-	output.Context.ResponseWriter.WriteHeader(status)
 	output.Status = status
 }
 

--- a/router.go
+++ b/router.go
@@ -762,6 +762,11 @@ Admin:
 			Info("beego:" + r.URL.Path + " 404" + " +" + timeend.String())
 		}
 	}
+
+	// Call WriteHeader if status code has been set changed
+	if context.Output.Status != 0 {
+		w.writer.WriteHeader(context.Output.Status)
+	}
 }
 
 func (p *ControllerRegistor) recoverPanic(rw http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
### Problem description

By calling this.Ctx.Output.SetStatus(xyz) the Response Header is sent immediately. Headers that are added afterwards are ignored, including the Content-Encoding (e.g. gzip) and the Content-Type (e.g. Json).
This prevents us from serving Json in body with an error messages together with the http-code.
### Fix

I removed the call to WriteHeader in SetStatus, so the header is not sent when SetStatus is called, instead it is postponed it to two places:
1. context's function "Body", right before writing the body (which implicitly writes the header first, but with status code 200 by default)
2. at the end of beego's ServeHTTP-method in router.go, but only if the status has been changed (if it is not 0)
The first case only happens when controller's ServeXYZ is called. By setting output.Status to 0 I prevent WriteHeader from being executed twice.
### Example of header before/after fix

```
func (this *SomeController) Get() {
    // ...
    responseBody := ErrorResponse{Message: "AccessToken invalid"}
    this.Data["json"] = responseBody
    this.Ctx.Output.SetStatus(403)
    this.Ctx.Output.Header("Access-Control-Allow-Origin", "*")
    this.ServeJson()
}
```

Resulted before in this response header:

```
Status 403 Forbidden
Date: Tue, 08 Jul 2014 20:37:23 GMT 
Content-Length: 61 
Content-Type: application/x-gzip
```

With gzip the body cannot be automatically decompressed due to missing header "Content-Encoding"

Results now in this response header:

```
Status 403 Forbidden
Access-Control-Allow-Origin: *
Content-Encoding: gzip 
Content-Type: application/json;charset=UTF-8 
Server: beegoServer:1.3.2 
Date: Tue, 08 Jul 2014 20:39:34 GMT 
Content-Length: 61
```

the json with the error message is served correctly in the body
