### PR TITLE
Update smtp.go

### DIFF
--- a/logs/smtp.go
+++ b/logs/smtp.go
@@ -55,6 +55,18 @@ func (s *SmtpWriter) Init(jsonconfig string) error {
 	return nil
 }
 
+func (s *SmtpWriter) GetSmtpAuth(host string) smtp.Auth {
+	if len(strings.Trim(s.Username, " ")) == 0 && len(strings.Trim(s.Password, " ")) == 0 {
+		return nil
+	}
+	return smtp.PlainAuth(
+		"",
+		s.Username,
+		s.Password,
+		host,
+	)
+}
+
 // write message in smtp writer.
 // it will send an email with subject and only this message.
 func (s *SmtpWriter) WriteMsg(msg string, level int) error {
@@ -65,12 +77,8 @@ func (s *SmtpWriter) WriteMsg(msg string, level int) error {
 	hp := strings.Split(s.Host, ":")
 
 	// Set up authentication information.
-	auth := smtp.PlainAuth(
-		"",
-		s.Username,
-		s.Password,
-		hp[0],
-	)
+	auth := s.GetSmtpAuth(hp[0])
+	
 	// Connect to the server, authenticate, set the sender and recipient,
 	// and send the email all in one step.
 	content_type := "Content-Type: text/plain" + "; charset=UTF-8"


### PR DESCRIPTION
For mail servers that do not require Authentication we must pass NIL for the SendMail parameter 2 (the auth parameter). Otherwise it fails to send the mail.
