### PR TITLE
revise the comment

### DIFF
--- a/logs/log.go
+++ b/logs/log.go
@@ -151,7 +151,7 @@ func (bl *BeeLogger) EnableFuncCallDepth(b bool) {
 }
 
 // start logger chan reading.
-// when chan is full, write logs.
+// when chan is not empty, write logs.
 func (bl *BeeLogger) startLogger() {
 	for {
 		select {


### PR DESCRIPTION
The channel is a buffer with the size of channellen.
No matter the  buffer is full or not, so long as it reads one, it will write the message to all it's outputs.
Thus the comment "when chan is full, write logs." is wrong.

I have another concern here.
the member outputs of BeeLogger is not thread-safe.
it may result in some problems.
For example, some function such as func (bl *BeeLogger) SetLogger(adaptername string, config string) error
appends a new write to outpusts while another function such as func (bl *BeeLogger) startLogger() iterators outputs.
