### PR TITLE
revise the comment of SliceIntersect

### DIFF
--- a/utils/slice.go
+++ b/utils/slice.go
@@ -101,7 +101,7 @@ func SliceDiff(slice1, slice2 []interface{}) (diffslice []interface{}) {
 	return
 }
 
-// SliceIntersect returns diff slice of slice2 - slice1.
+// SliceIntersect returns diff slice of slice1 - slice2.
 func SliceIntersect(slice1, slice2 []interface{}) (diffslice []interface{}) {
 	for _, v := range slice1 {
 		if !InSliceIface(v, slice2) {


### PR DESCRIPTION
The implementations of SliceDiff and SliceIntersect are the same.
However, the comments of them are opposite.
FYI: the former is (slice1 - slice2) while the latter is (slice2- slice1)
