### PR TITLE
fix session

### DIFF
--- a/beego.go
+++ b/beego.go
@@ -362,7 +362,7 @@ func initBeforeHttpRun() {
 				`"sessionIDHashFunc":"` + SessionHashFunc + `",` +
 				`"sessionIDHashKey":"` + SessionHashKey + `",` +
 				`"enableSetCookie":` + strconv.FormatBool(SessionAutoSetCookie) + `,` +
-				`"domain":` + SessionDomain + `,` +
+				`"domain":"` + SessionDomain + `",` +
 				`"cookieLifeTime":` + strconv.Itoa(SessionCookieLifeTime) + `}`
 		}
 		GlobalSessions, err = session.NewManager(SessionProvider,


### PR DESCRIPTION
fix session

```
panic: invalid character ',' looking for beginning of value

goroutine 16 [running]:
runtime.panic(0x87d1c0, 0x13b3eb10)
        D:/Develop/go/src/pkg/runtime/panic.c:279 +0xe9
github.com/astaxie/beego.initBeforeHttpRun()
        D:/Users/zh/IdeaProjects/golang/src/github.com/astaxie/beego/beego.go:371 +0x3d7
github.com/astaxie/beego.Run(0x0, 0x0, 0x0)
        D:/Users/zh/IdeaProjects/golang/src/github.com/astaxie/beego/beego.go:327 +0xee
main.main()
        D:/Users/zh/IdeaProjects/golang/src/tsapi/main.go:48 +0x4c
```
