### PR TITLE
[orm] improve null pointer panic message

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.idea
 .DS_Store
 *.swp
 *.swo

--- a/orm/models_utils.go
+++ b/orm/models_utils.go
@@ -132,6 +132,9 @@ func getFieldType(val reflect.Value) (ft int, err error) {
 	case reflect.String:
 		ft = TypeCharField
 	default:
+		if elm == nil {
+			panic(fmt.Errorf("%s is nil pointer, may be miss setting tag", val))
+		}
 		switch elm.Interface().(type) {
 		case sql.NullInt64:
 			ft = TypeBigIntegerField


### PR DESCRIPTION
i didn't add some tags and got this panic message:

```
panic: reflect: call of reflect.Value.Interface on zero Value

goroutine 16 [running]:
runtime.panic(0x8b7da0, 0xc2080fe100)
    /usr/local/go/src/pkg/runtime/panic.c:279 +0xf5
reflect.valueInterface(0x0, 0x0, 0x0, 0x0, 0x1, 0x0, 0x0)
    /usr/local/go/src/pkg/reflect/value.go:1075 +0xa7
reflect.Value.Interface(0x0, 0x0, 0x0, 0x0, 0x0, 0x0)
    /usr/local/go/src/pkg/reflect/value.go:1070 +0x5c
github.com/astaxie/beego/orm.getFieldType(0x8b8020, 0xc208018908, 0x0, 0x166, 0x0, 0x0, 0x0)
    /var/www/go/src/github.com/astaxie/beego/orm/models_utils.go:135 +0x27e
github.com/astaxie/beego/orm.newFieldInfo(0xc20804e3c0, 0x8b8020, 0xc208018908, 0x0, 0x166, 0x980230, 0x4, 0x0, 0x0, 0x7f49f94981d8, ...)
    /var/www/go/src/github.com/astaxie/beego/orm/models_info_f.go:228 +0x2c40
github.com/astaxie/beego/orm.newModelInfo(0x7e5f40, 0xc2080188c0, 0x0, 0x160, 0xc20804e3c0)
    /var/www/go/src/github.com/astaxie/beego/orm/models_info_m.go:59 +0x45f
github.com/astaxie/beego/orm.registerModel(0x96fcb0, 0x0, 0x7e5f40, 0xc2080188c0)
    /var/www/go/src/github.com/astaxie/beego/orm/models_boot.go:49 +0x5ef
github.com/astaxie/beego/orm.RegisterModelWithPrefix(0x96fcb0, 0x0, 0x7f49f930df00, 0x1, 0x1)
    /var/www/go/src/github.com/astaxie/beego/orm/models_boot.go:309 +0x12f
github.com/astaxie/beego/orm.RegisterModel(0x7f49f930df00, 0x1, 0x1)
    /var/www/go/src/github.com/astaxie/beego/orm/models_boot.go:299 +0x52
```

it's very unclear. i wan't improve it to some more valuable message like:

```
panic: <*models.GoalCategory Value> is nil pointer, may be miss setting tag
```
