### PR TITLE
improve the 'geturl'

### DIFF
--- a/router.go
+++ b/router.go
@@ -459,7 +459,7 @@ func (p *ControllerRegistor) geturl(t *Tree, url, controllName, methodName strin
 				if find {
 					if l.regexps == nil {
 						if len(l.wildcards) == 0 {
-							return true, strings.Replace(url, "/"+url_placeholder, "", 1)
+							return true, strings.Replace(url, "/"+url_placeholder, "", 1) + tourl(params)
 						}
 						if len(l.wildcards) == 1 {
 							if v, ok := params[l.wildcards[0]]; ok {


### PR DESCRIPTION
If we have a url mapping like this:
`beego.Router(“/test”, &controllers.DemoController{},"get:Test”)`
when you use `UrlFor(“DemoController.Test”, “foo”, 1, “bar”, 2 )`,
it should return `/test?foo=1&bar=2` rather than `/test`.
