### PR TITLE
Add CustomAbort() for Controller, support status code and body

### DIFF
--- a/controller.go
+++ b/controller.go
@@ -274,6 +274,11 @@ func (c *Controller) Abort(code string) {
 	}
 }
 
+// CustomAbort stops controller handler and show the error data, it's similar Aborts, but support status code and body.
+func (c *Controller) CustomAbort(status int, body string) {
+	c.Ctx.Abort(status, body)
+}
+
 // StopRun makes panic of USERSTOPRUN error and go to recover function if defined.
 func (c *Controller) StopRun() {
 	panic(USERSTOPRUN)


### PR DESCRIPTION
Example:

```
this.CustomAbort(200, "this is error")
```
