### PR TITLE
support bit(1) data type of MySQL

### DIFF
--- a/orm/db.go
+++ b/orm/db.go
@@ -1073,6 +1073,13 @@ setValue:
 			}
 		}
 		if str != nil {
+			switch v := val.(type) {
+			case []byte:
+				if len(v) == 1 {
+					value = v[0] == 1
+					goto end
+				}
+			}
 			b, err := str.Bool()
 			if err != nil {
 				tErr = err


### PR DESCRIPTION
MySQL从5.0.3版本开始bit(1)改成二进制类型，不再作为tinyint(1)的同义词，这样里面存放的bool值也相应的从1、0改为了\x01、\x00。
现在beego orm生成的代码会把bit(1)转成uint64，这样执行过程中就会出错：
Raw value: `[0]` convert to `*uint64` failed, field: fooDao/models.User.IsBar err: strconv.ParseUint: parsing "\x00": invalid syntax
修改了一下代码，在读取数据的转换过程中对这种情况做了个判断。
