### PR TITLE
fixed uninitialized return error if StartAndGC fails

### DIFF
--- a/cache/cache.go
+++ b/cache/cache.go
@@ -81,13 +81,13 @@ func Register(name string, adapter Cache) {
 // Create a new cache driver by adapter name and config string.
 // config need to be correct JSON as string: {"interval":360}.
 // it will start gc automatically.
-func NewCache(adapterName, config string) (adapter Cache, e error) {
+func NewCache(adapterName, config string) (adapter Cache, err error) {
 	adapter, ok := adapters[adapterName]
 	if !ok {
-		e = fmt.Errorf("cache: unknown adapter name %q (forgot to import?)", adapterName)
+		err = fmt.Errorf("cache: unknown adapter name %q (forgot to import?)", adapterName)
 		return
 	}
-	err := adapter.StartAndGC(config)
+	err = adapter.StartAndGC(config)
 	if err != nil {
 		adapter = nil
 	}


### PR DESCRIPTION
if the error is caused by adapter.StartAndGC, the error that should be returned is not properly updated
instead, a local variable is created and used
