### PR TITLE
[Proposal] Ability to get statistics data unformatted 

### DIFF
--- a/toolbox/statistics.go
+++ b/toolbox/statistics.go
@@ -15,7 +15,6 @@
 package toolbox
 
 import (
-	"encoding/json"
 	"fmt"
 	"sync"
 	"time"
@@ -112,11 +111,7 @@ func (m *UrlMap) GetMap() map[string]interface{} {
 	return content
 }
 
-func (m *UrlMap) GetMapJSON() ([]byte, error) {
-	return json.Marshal(m)
-}
-
-func (m UrlMap) MarshalJSON() ([]byte, error) {
+func (m *UrlMap) GetMapData() []map[string]interface{} {
 
 	resultLists := make([]map[string]interface{}, 0)
 
@@ -134,7 +129,7 @@ func (m UrlMap) MarshalJSON() ([]byte, error) {
 			resultLists = append(resultLists, result)
 		}
 	}
-	return json.Marshal(resultLists)
+	return resultLists
 }
 
 // global statistics data map

--- a/toolbox/statistics_test.go
+++ b/toolbox/statistics_test.go
@@ -15,6 +15,7 @@
 package toolbox
 
 import (
+	"encoding/json"
 	"testing"
 	"time"
 )
@@ -29,9 +30,11 @@ func TestStatics(t *testing.T) {
 	StatisticsMap.AddStatistics("DELETE", "/api/user", "&admin.user", time.Duration(1400))
 	t.Log(StatisticsMap.GetMap())
 
-	jsonString, err := StatisticsMap.GetMapJSON()
+	data := StatisticsMap.GetMapData()
+	b, err := json.Marshal(data)
 	if err != nil {
 		t.Errorf(err.Error())
 	}
-	t.Log(string(jsonString))
+
+	t.Log(string(b))
 }


### PR DESCRIPTION
Ability to get stats data in a format that can be easily placed into a controller and served as JSON. 

Sample status controller code: 

``` go
 // @router / [get]
 func (this *StatusController) GetStatus() {

     this.Data["json"] = toolbox.StatisticsMap.GetMapData()
     this.ServeJson()
     return
 }
```

The output of GetMap() changed from v1.4.0 to v1.4.1 - my controller previously parsed that output and generated JSON.  Instead of having to changed the parsing code in the controller, this method can just provide the data ready to be JSON encoded.
