### PR TITLE
Allow to use fastcgi via standard io.

### DIFF
--- a/config.go
+++ b/config.go
@@ -61,6 +61,7 @@ var (
 	SessionAutoSetCookie   bool             // auto setcookie
 	SessionDomain          string           // the cookie domain default is empty
 	UseFcgi                bool
+	UseStdIo               bool
 	MaxMemory              int64
 	EnableGzip             bool // flag of enable gzip
 	DirectoryIndex         bool // flag of display directory index. default is false.
@@ -241,6 +242,7 @@ func init() {
 	SessionAutoSetCookie = true
 
 	UseFcgi = false
+	UseStdIo = false
 
 	MaxMemory = 1 << 26 //64MB
 


### PR DESCRIPTION
Passing `nil` as the first parameter to `fcgi.Serve()` (e.g. `fcgi.Serve(nil, app.Handlers)`) will enable using standard I/O instead of tcp/unix sockets. This is useful to deploy applications in shared hosting environments where you are not allowed to use tcp/unix sockets.

I put together an example using go + apache + fastcgi via standard I/O here: https://github.com/bsingr/golang-apache-fastcgi.
