### PR TITLE
fix router bug: when the request is PUT or DELETE, router can't find the...

### DIFF
--- a/router.go
+++ b/router.go
@@ -626,7 +626,21 @@ func (p *ControllerRegistor) ServeHTTP(rw http.ResponseWriter, r *http.Request) 
 	}
 
 	if !findrouter {
-		if t, ok := p.routers[r.Method]; ok {
+		http_method := ""
+
+		if r.Method == "POST" && context.Input.Query("_method") == "PUT" {
+			http_method = "PUT"
+		}
+
+		if r.Method == "POST" && context.Input.Query("_method") == "DELETE" {
+			http_method = "DELETE"
+		}
+
+		if http_method != "PUT" && http_method != "DELETE" {
+			http_method = r.Method
+		}
+
+		if t, ok := p.routers[http_method]; ok {
 			runObject, p := t.Match(r.URL.Path)
 			if r, ok := runObject.(*controllerInfo); ok {
 				routerInfo = r


### PR DESCRIPTION
fix router bug: when the request is PUT or DELETE, router can't find the actual route and will throw 404 page to user

我遇到的狀況：

我在 router 定義了這一段 route:

beego.Router("/admin/posts/:id([0-9]+)/update", &controllers.PostController{}, "put:Update")

我嘗試在 form 裡面塞一段 hidden input ，name 裡面填入 _method ，value 填 PUT （因為我在 beego source code 裡面有看到判斷是否為 PUT 是檢查 _method 這個東西）

結果不管怎樣 router 都找不到這個 route

後來看 source code 發現問題：

router.go 裡面有這麼一段 code 

```
    if t, ok := p.routers[r.Method]; ok {
        runObject, p := t.Match(r.URL.Path)
        if r, ok := runObject.(*controllerInfo); ok {
            routerInfo = r
            findrouter = true
            if splat, ok := p[":splat"]; ok {
                splatlist := strings.Split(splat, "/")
                for k, v := range splatlist {
                    p[strconv.Itoa(k)] = v
                }
            }
            context.Input.Params = p
        }
    }
```

p.routers[r.Method] 就是問題的根源。今天我在 form 裡面塞一段 _method 也沒用是因為，它在檢查的時候是直接用使用者 request 的 HTTP method 來找，因此它會去找 POST request 的路由裡面找有沒有我定義的 PUT route，所以當然找不到
