### PR TITLE
Use SETEX command to set session

### DIFF
--- a/session/redis/sess_redis.go
+++ b/session/redis/sess_redis.go
@@ -109,7 +109,7 @@ func (rs *RedisSessionStore) SessionRelease(w http.ResponseWriter) {
 		return
 	}
 
-	c.Do("SET", rs.sid, string(b), "EX", rs.maxlifetime)
+	c.Do("SETEX", rs.sid, rs.maxlifetime, string(b))
 }
 
 // redis session provider


### PR DESCRIPTION
In order to be compatible with older version Redis (< 2.6.12), use `SETEX` command instead of `SET x y EX 360`.
