### PR TITLE
add new feature to 'renderform' function, user could add HTML id and class now

### DIFF
--- a/templatefunc.go
+++ b/templatefunc.go
@@ -380,11 +380,19 @@ func RenderForm(obj interface{}) template.HTML {
 
 // renderFormField returns a string containing HTML of a single form field.
 func renderFormField(label, name, fType string, value interface{}, id string, class string) string {
-	if isValidForInput(fType) {
-		return fmt.Sprintf(`%v<input id="%v" class="%v" name="%v" type="%v" value="%v">`, label, id, class, name, fType, value)
+	if id != "" {
+		id = "id=\"" + id + "\""
 	}
 
-	return fmt.Sprintf(`%v<%v id="%v" class="%v" name="%v">%v</%v>`, label, fType, id, class, name, value, fType)
+	if class != "" {
+		class = "class=\"" + class + "\""
+	}
+
+	if isValidForInput(fType) {
+		return fmt.Sprintf(`%v<input %v %v name="%v" type="%v" value="%v">`, label, id, class, name, fType, value)
+	}
+
+	return fmt.Sprintf(`%v<%v %v %v name="%v">%v</%v>`, label, fType, id, class, name, value, fType)
 }
 
 // isValidForInput checks if fType is a valid value for the `type` property of an HTML input element.


### PR DESCRIPTION
目前 renderform 無法讓使用者自訂 HTML 的 id, class ，故針對這部份做了功能新增。

使用方式如下：

type Post struct {
    Id        int64  `form:"-"`
    Title     string `form:"post_title" id:"post_title" class:"form-control"`
    Path      string `form:"post_path" id:"post_path" class:"form-control"`
    Content   string `form:"post_content,textarea" id:"post_content"`
}

請注意上面的 Title, Path 以及 Content 。使用方式非常簡單，只要額外增加 id 以及 class 這兩個 struct tag 即可。
