### PR TITLE
修复dev存在同名配置时，正确的配置项被覆盖的问题

### DIFF
--- a/config.go
+++ b/config.go
@@ -189,6 +189,10 @@ func ParseConfig() (err error) {
 		return err
 	} else {
 
+		if runmode, _ := GetConfig("string", "RunMode"); runmode != "" {
+			RunMode = runmode.(string)
+		}
+
 		if v, err := GetConfig("string", "HttpAddr"); err == nil {
 			HttpAddr = v.(string)
 		}
@@ -207,10 +211,6 @@ func ParseConfig() (err error) {
 
 		if appname, _ := GetConfig("string", "AppName"); appname != "" {
 			AppName = appname.(string)
-		}
-
-		if runmode, _ := GetConfig("string", "RunMode"); runmode != "" {
-			RunMode = runmode.(string)
 		}
 
 		if autorender, err := GetConfig("bool", "AutoRender"); err == nil {


### PR DESCRIPTION
When the app.conf has [dev] section, the same config item of [dev] section will overwrite the global or other section config item, no matter what `runmode`

for example:
// app.conf

runmode=prod
httpport=80
[dev]
httpport=8080
[prod]
httpport=80

when call to beego.Run, it will use 8080 as the value of beego.HttpPort, not expected 80
