### PR TITLE
Bug/Improvement: Delay WriteHeader to enable Handler to change header/statuscode

### DIFF
--- a/httplib/SyncedResponseWriter.go
+++ b/httplib/SyncedResponseWriter.go
@@ -1,0 +1,49 @@
+package httplib
+
+import "net/http"
+
+// SyncedResponseWriter is a wrapper for the http.ResponseWriter
+// A call to writeHeader will not actually send the header, but instead store the status-code until Write or
+// SendHeader is called
+type SyncedResponseWriter struct{
+	writer        http.ResponseWriter
+	headerWritten bool
+	status        int
+}
+
+func NewSyncedResponseWriter(rw http.ResponseWriter) *SyncedResponseWriter{
+	return &SyncedResponseWriter{writer: rw, headerWritten: false, status: 200}
+}
+
+// Header returns the header map that will be sent by WriteHeader.
+func (w *SyncedResponseWriter) Header() http.Header {
+	return w.writer.Header()
+}
+
+// Write writes the data to the connection as part of an HTTP reply,
+func (w *SyncedResponseWriter) Write(p []byte) (int, error) {
+	if !w.headerWritten {
+		w.SendHeader()
+	}
+	return w.writer.Write(p)
+}
+
+// WriteHeader stores an http status code for future write
+func (w *SyncedResponseWriter) WriteHeader(code int) {
+	w.status = code
+}
+
+// SendHeader sends an HTTP response header with status code,
+// and sets `started` to true.
+func (w *SyncedResponseWriter) SendHeader() {
+	if w.status == 0 {
+		w.WriteHeader(200)
+	}
+	w.headerWritten = true
+	w.writer.WriteHeader(w.status)
+}
+
+// IsHeaderWritten returns weather the header has been sent or not
+func (w *SyncedResponseWriter) IsHeaderWritten() bool {
+	return w.headerWritten
+}

--- a/router.go
+++ b/router.go
@@ -33,6 +33,7 @@ import (
 	"github.com/astaxie/beego/middleware"
 	"github.com/astaxie/beego/toolbox"
 	"github.com/astaxie/beego/utils"
+	"github.com/astaxie/beego/httplib"
 )
 
 const (
@@ -556,7 +557,14 @@ func (p *ControllerRegistor) geturl(t *Tree, url, controllName, methodName strin
 }
 
 // Implement http.Handler interface.
-func (p *ControllerRegistor) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
+func (p *ControllerRegistor) ServeHTTP(originalRw http.ResponseWriter, r *http.Request) {
+	rw := httplib.NewSyncedResponseWriter(originalRw)
+	defer func() {
+		if !rw.IsHeaderWritten() {
+			rw.SendHeader()
+		}
+	}()
+
 	defer p.recoverPanic(rw, r)
 	starttime := time.Now()
 	var runrouter reflect.Type


### PR DESCRIPTION
### Problem

**Headers and statuscode** are already written when a handler (e.g. 404-handler) is called, therefore the author of a handler cannot change these.
### Changes made

I wrote a wrapper for ResponseWriter which doesn't forward writeHeader on its inner http.ResponseWriter immediately. Instead it stores the status code until Write or SendHeader is called. Therefore it is possible to call WriteHeader multiple times and the last one will be sent.
Additionaly SendHeader is called in a deferred method of ServeHTTP (executed AFTER recoverPanic is executed) to ensure that a Header is written.

Here a visualization of the flow in case of Exception, Abort and Panic:
![flow](https://cloud.githubusercontent.com/assets/6203829/4862458/c5142bb6-610c-11e4-9567-b3ba59d11586.png)
