### PR TITLE
Return the response directly if it's a options PreflightHeader request

### DIFF
--- a/plugins/cors/cors.go
+++ b/plugins/cors/cors.go
@@ -217,6 +217,7 @@ func Allow(opts *Options) beego.FilterFunc {
 				ctx.Output.Header(key, value)
 			}
 			ctx.Output.SetStatus(http.StatusOK)
+			ctx.WriteString("")
 			return
 		}
 		headers = opts.Header(origin)


### PR DESCRIPTION
If it's a Preflighted requests, return the response directly after the preflight headers are set.

Prevented the options method in the requested controlled been called.
