### PR TITLE
count log file lines

### DIFF
--- a/logs/file.go
+++ b/logs/file.go
@@ -15,10 +15,11 @@
 package logs
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"os"
 	"path/filepath"
@@ -170,15 +171,42 @@ func (w *FileLogWriter) initFd() error {
 	w.maxsize_cursize = int(finfo.Size())
 	w.daily_opendate = time.Now().Day()
 	if finfo.Size() > 0 {
-		content, err := ioutil.ReadFile(w.Filename)
+		count, err := w.lines()
 		if err != nil {
 			return err
 		}
-		w.maxlines_curlines = len(strings.Split(string(content), "\n"))
+		w.maxlines_curlines = count
 	} else {
 		w.maxlines_curlines = 0
 	}
 	return nil
+}
+
+func (w *FileLogWriter) lines() (int, error) {
+	fd, err := os.Open(w.Filename)
+	if err != nil {
+		return 0, err
+	}
+	defer fd.Close()
+
+	buf := make([]byte, 32768) // 32k
+	count := 0
+	lineSep := []byte{'\n'}
+
+	for {
+		c, err := fd.Read(buf)
+		if err != nil && err != io.EOF {
+			return count, err
+		}
+
+		count += bytes.Count(buf[:c], lineSep)
+
+		if err == io.EOF {
+			break
+		}
+	}
+
+	return count, nil
 }
 
 // DoRotate means it need to write file in new file.


### PR DESCRIPTION
To count the lines of an exist log file, there is no need (and not suggested) to read all the content at once.
