### PR TITLE
beego1.4.2，beego.AppConfig.Strings与老版本代码不兼容问题  

### DIFF
--- a/config.go
+++ b/config.go
@@ -110,7 +110,7 @@ func (b *beegoAppConfig) String(key string) string {
 
 func (b *beegoAppConfig) Strings(key string) []string {
 	v := b.innerConfig.Strings(RunMode + "::" + key)
-	if len(v) == 0 {
+	if v[0] == "" {
 		return b.innerConfig.Strings(key)
 	}
 	return v


### PR DESCRIPTION
beego.AppConfig.Strings在新版本中无法正常取得数组内容
