### PR TITLE
make Content-Type header more human-readable

### DIFF
--- a/context/output.go
+++ b/context/output.go
@@ -188,7 +188,7 @@ func sanitizeValue(v string) string {
 // Json writes json to response body.
 // if coding is true, it converts utf-8 to \u0000 type.
 func (output *BeegoOutput) Json(data interface{}, hasIndent bool, coding bool) error {
-	output.Header("Content-Type", "application/json;charset=UTF-8")
+	output.Header("Content-Type", "application/json; charset=utf-8")
 	var content []byte
 	var err error
 	if hasIndent {
@@ -209,7 +209,7 @@ func (output *BeegoOutput) Json(data interface{}, hasIndent bool, coding bool) e
 
 // Jsonp writes jsonp to response body.
 func (output *BeegoOutput) Jsonp(data interface{}, hasIndent bool) error {
-	output.Header("Content-Type", "application/javascript;charset=UTF-8")
+	output.Header("Content-Type", "application/javascript; charset=utf-8")
 	var content []byte
 	var err error
 	if hasIndent {
@@ -235,7 +235,7 @@ func (output *BeegoOutput) Jsonp(data interface{}, hasIndent bool) error {
 
 // Xml writes xml string to response body.
 func (output *BeegoOutput) Xml(data interface{}, hasIndent bool) error {
-	output.Header("Content-Type", "application/xml;charset=UTF-8")
+	output.Header("Content-Type", "application/xml; charset=utf-8")
 	var content []byte
 	var err error
 	if hasIndent {


### PR DESCRIPTION
Make Content-Type header more human-readable.

Original:

```
Content-Type: application/json;charset=UTF-8
```

Modified:

```
Content-Type: application/json; charset=utf-8
```
