### PR TITLE
Fix paginator attributes can‘t be modified bug

### DIFF
--- a/utils/pagination/controller.go
+++ b/utils/pagination/controller.go
@@ -21,6 +21,6 @@ import (
 // Instantiates a Paginator and assigns it to context.Input.Data["paginator"].
 func SetPaginator(context *context.Context, per int, nums int64) (paginator *Paginator) {
 	paginator = NewPaginator(context.Request, per, nums)
-	context.Input.Data["paginator"] = paginator
+	context.Input.Data["paginator"] = &paginator
 	return
 }


### PR DESCRIPTION
We can only use SetPaginator to create a pagination.

After that, we always need to modify something, like the totalNum, perPageNum.

These change should be seen in the view.

So we should give the view a pointer than a object.
