### PR TITLE
给Controller添加带默认值的GetString()版本

### DIFF
--- a/controller.go
+++ b/controller.go
@@ -368,6 +368,15 @@ func (c *Controller) GetString(key string) string {
 	return c.Ctx.Input.Query(key)
 }
 
+// GetStringWithDefault returns the input value by key string with default value.
+func (c *Controller) GetStringWithDefault(key, default string) string {
+	val := this.GetString(key)
+	if val=="" {
+		return default
+	}
+	return val
+}
+
 // GetStrings returns the input string slice by key string.
 // it's designed for multi-value input field such as checkbox(input[type=checkbox]), multi-selection.
 func (c *Controller) GetStrings(key string) []string {


### PR DESCRIPTION
出发点和解析配置文件时的`DefaultString()`方法一样。

虽然框架外用户也可以实现同样的功能，但是写在框架内，用户空间代码更清爽。

如果可以采纳，我就顺带的把其他几个获取参数的方法一并修改。
