### PR TITLE
Add all type support for UrlFor’s params

### DIFF
--- a/controller.go
+++ b/controller.go
@@ -289,7 +289,7 @@ func (c *Controller) StopRun() {
 
 // UrlFor does another controller handler in this request function.
 // it goes to this controller method if endpoint is not clear.
-func (c *Controller) UrlFor(endpoint string, values ...string) string {
+func (c *Controller) UrlFor(endpoint string, values ...interface{}) string {
 	if len(endpoint) <= 0 {
 		return ""
 	}

--- a/router.go
+++ b/router.go
@@ -429,7 +429,7 @@ func (p *ControllerRegistor) insertFilterRouter(pos int, mr *FilterRouter) error
 
 // UrlFor does another controller handler in this request function.
 // it can access any controller method.
-func (p *ControllerRegistor) UrlFor(endpoint string, values ...string) string {
+func (p *ControllerRegistor) UrlFor(endpoint string, values ...interface{}) string {
 	paths := strings.Split(endpoint, ".")
 	if len(paths) <= 1 {
 		Warn("urlfor endpoint must like path.controller.method")
@@ -444,9 +444,9 @@ func (p *ControllerRegistor) UrlFor(endpoint string, values ...string) string {
 		key := ""
 		for k, v := range values {
 			if k%2 == 0 {
-				key = v
+				key = fmt.Sprint(v)
 			} else {
-				params[key] = v
+				params[key] = fmt.Sprint(v)
 			}
 		}
 	}

--- a/templatefunc.go
+++ b/templatefunc.go
@@ -246,7 +246,7 @@ func Htmlunquote(src string) string {
 //	/user/John%20Doe
 //
 //  more detail http://beego.me/docs/mvc/controller/urlbuilding.md
-func UrlFor(endpoint string, values ...string) string {
+func UrlFor(endpoint string, values ...interface{}) string {
 	return BeeApp.Handlers.UrlFor(endpoint, values...)
 }
 


### PR DESCRIPTION
修改UrlFor，使之支持所有类型的参数（而不仅是string）
