### PR TITLE
Fix RequestURI nil caused template parse failed

### DIFF
--- a/utils/pagination/paginator.go
+++ b/utils/pagination/paginator.go
@@ -114,7 +114,7 @@ func (p *Paginator) Pages() []int {
 
 // Returns URL for a given page index.
 func (p *Paginator) PageLink(page int) string {
-	link, _ := url.ParseRequestURI(p.Request.RequestURI)
+	link, _ := url.ParseRequestURI(p.Request.URL.String())
 	values := link.Query()
 	if page == 1 {
 		values.Del("p")


### PR DESCRIPTION
Sometime RequestURI is not set, e.g. running after a front proxy server.

We should always follow the document's directive, to use Request.URL instead of RequestURI.

Refer: http://golang.org/pkg/net/http/#Request
