### PR TITLE
fix(orm/orm_raw): missing type time parse

### DIFF
--- a/client/orm/orm_raw.go
+++ b/client/orm/orm_raw.go
@@ -181,6 +181,12 @@ func (o *rawSet) setFieldValue(ind reflect.Value, value interface{}) {
 					if err == nil {
 						ind.Set(reflect.ValueOf(t))
 					}
+				} else if len(str) >= 8 {
+					str = str[:8]
+					t, err := time.ParseInLocation(formatTime, str, DefaultTimeLoc)
+					if err == nil {
+						ind.Set(reflect.ValueOf(t))
+					}
 				}
 			}
 		case sql.NullString, sql.NullInt64, sql.NullFloat64, sql.NullBool:

--- a/client/orm/orm_test.go
+++ b/client/orm/orm_test.go
@@ -1746,6 +1746,10 @@ func TestRawQueryRow(t *testing.T) {
 			throwFail(t, AssertIs(id, 1))
 			break
 		case "time":
+			v = v.(time.Time).In(DefaultTimeLoc)
+			value := dataValues[col].(time.Time).In(DefaultTimeLoc)
+			assert.True(t, v.(time.Time).Sub(value) <= time.Second)
+			break
 		case "date":
 		case "datetime":
 			v = v.(time.Time).In(DefaultTimeLoc)


### PR DESCRIPTION
I use beego in v1.12 , map `mysql` type `time` to struct is fail by `QueryRow` . 
This problem also seems to exist in this branch.