### PR TITLE
Fix 4365

### DIFF
--- a/server/web/controller_test.go
+++ b/server/web/controller_test.go
@@ -21,8 +21,6 @@ import (
 	"strconv"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
-
 	"github.com/beego/beego/v2/server/web/context"
 )
 
@@ -127,10 +125,9 @@ func TestGetUint64(t *testing.T) {
 }
 
 func TestAdditionalViewPaths(t *testing.T) {
-	wkdir, err := os.Getwd()
-	assert.Nil(t, err)
-	dir1 := filepath.Join(wkdir, "_beeTmp", "TestAdditionalViewPaths")
-	dir2 := filepath.Join(wkdir, "_beeTmp2", "TestAdditionalViewPaths")
+	tmpDir := os.TempDir()
+	dir1 := filepath.Join(tmpDir, "_beeTmp", "TestAdditionalViewPaths")
+	dir2 := filepath.Join(tmpDir, "_beeTmp2", "TestAdditionalViewPaths")
 	defer os.RemoveAll(dir1)
 	defer os.RemoveAll(dir2)
 

--- a/server/web/parser.go
+++ b/server/web/parser.go
@@ -584,17 +584,6 @@ func getpathTime(pkgRealpath string) (lastupdate int64, err error) {
 
 func getRouterDir(pkgRealpath string) string {
 	dir := filepath.Dir(pkgRealpath)
-	for {
-		routersDir := AppConfig.DefaultString("routersdir", "routers")
-		d := filepath.Join(dir, routersDir)
-		if utils.FileExists(d) {
-			return d
-		}
-
-		if r, _ := filepath.Rel(dir, AppPath); r == "." {
-			return d
-		}
-		// Parent dir.
-		dir = filepath.Dir(dir)
-	}
+	routersDir := AppConfig.DefaultString("routersdir", "routers")
+	return filepath.Join(dir, routersDir)
 }

--- a/server/web/parser_test.go
+++ b/server/web/parser_test.go
@@ -1,0 +1,34 @@
+// Copyright 2020 beego
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package web
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_getRouterDir(t *testing.T)  {
+	pkg := filepath.Dir(os.TempDir())
+
+	res := getRouterDir(pkg)
+	assert.Equal(t, filepath.Join(pkg, "routers"), res)
+	AppConfig.Set("routersdir", "cus_routers")
+	res = getRouterDir(pkg)
+	assert.Equal(t, filepath.Join(pkg, "cus_routers"), res)
+
+}

--- a/server/web/template_test.go
+++ b/server/web/template_test.go
@@ -49,9 +49,8 @@ var block = `{{define "block"}}
 {{end}}`
 
 func TestTemplate(t *testing.T) {
-	wkdir, err := os.Getwd()
-	assert.Nil(t, err)
-	dir := filepath.Join(wkdir, "_beeTmp", "TestTemplate")
+	tmpDir := os.TempDir()
+	dir := filepath.Join(tmpDir, "_beeTmp", "TestTemplate")
 	files := []string{
 		"header.tpl",
 		"index.tpl",
@@ -113,9 +112,8 @@ var user = `<!DOCTYPE html>
 `
 
 func TestRelativeTemplate(t *testing.T) {
-	wkdir, err := os.Getwd()
-	assert.Nil(t, err)
-	dir := filepath.Join(wkdir, "_beeTmp")
+	tmpDir := os.TempDir()
+	dir := filepath.Join(tmpDir, "_beeTmp")
 
 	// Just add dir to known viewPaths
 	if err := AddViewPath(dir); err != nil {
@@ -226,10 +224,10 @@ var output = `<!DOCTYPE html>
 `
 
 func TestTemplateLayout(t *testing.T) {
-	wkdir, err := os.Getwd()
+	tmpDir, err := os.Getwd()
 	assert.Nil(t, err)
 
-	dir := filepath.Join(wkdir, "_beeTmp", "TestTemplateLayout")
+	dir := filepath.Join(tmpDir, "_beeTmp", "TestTemplateLayout")
 	files := []string{
 		"add.tpl",
 		"layout_blog.tpl",


### PR DESCRIPTION
Close #4365 
From current design, we only need to return the path and no need to look for exsiting dir.

It makes our logic much more simpler