### PR TITLE
fix router:AddMethod logic error, remove unreachable code

### DIFF
--- a/server/web/router.go
+++ b/server/web/router.go
@@ -390,13 +390,7 @@ func (p *ControllerRegister) AddMethod(method, pattern string, f FilterFunc) {
 	}
 	route.methods = methods
 	for k := range methods {
-		if k == "*" {
-			for m := range HTTPMETHOD {
-				p.addToRouter(m, pattern, route)
-			}
-		} else {
-			p.addToRouter(k, pattern, route)
-		}
+		p.addToRouter(k, pattern, route)
 	}
 }
 


### PR DESCRIPTION
````golang
// HTTPMETHOD list the supported http methods.
HTTPMETHOD = map[string]bool{
    "GET":       true,
    "POST":      true,
    "PUT":       true,
    "DELETE":    true,
    "PATCH":     true,
    "OPTIONS":   true,
    "HEAD":      true,
    "TRACE":     true,
    "CONNECT":   true,
    "MKCOL":     true,
    "COPY":      true,
    "MOVE":      true,
    "PROPFIND":  true,
    "PROPPATCH": true,
    "LOCK":      true,
    "UNLOCK":    true,
}


methods := make(map[string]string)
if method == "*" {
    for val := range HTTPMETHOD {
	methods[val] = val	
    }	
} else {
    methods[method] = method
}

// methods map will not have "*" key because of first HTTPMETHOD loop.
// so the if k == "*" will never be true.
for k := range methods {
    if k == "*" {	
	    for m := range HTTPMETHOD {	
		    p.addToRouter(m, pattern, route)	
	    }	
    } else {	
	    p.addToRouter(k, pattern, route)	
    }	
}

````

It seems like a logic error in the project. 