### PR TITLE
Make compatible: Router method in server.go

### DIFF
--- a/adapter/app.go
+++ b/adapter/app.go
@@ -74,7 +74,7 @@ func oldMiddlewareToNew(mws []MiddleWare) []web.MiddleWare {
 //  beego.Router("/api/update",&RestController{},"put:UpdateFood")
 //  beego.Router("/api/delete",&RestController{},"delete:DeleteFood")
 func Router(rootpath string, c ControllerInterface, mappingMethods ...string) *App {
-	return (*App)(web.Router(rootpath, c, web.SetRouterMethods(c, mappingMethods...)))
+	return (*App)(web.Router(rootpath, c, mappingMethods...))
 }
 
 // UnregisterFixedRoute unregisters the route with the specified fixedRoute. It is particularly useful

--- a/adapter/router.go
+++ b/adapter/router.go
@@ -87,7 +87,7 @@ func NewControllerRegister() *ControllerRegister {
 //	Add("/api",&RestController{},"get,post:ApiFunc"
 //	Add("/simple",&SimpleController{},"get:GetFunc;post:PostFunc")
 func (p *ControllerRegister) Add(pattern string, c ControllerInterface, mappingMethods ...string) {
-	(*web.ControllerRegister)(p).Add(pattern, c, web.SetRouterMethods(c, mappingMethods...))
+	(*web.ControllerRegister)(p).Add(pattern, c, web.WithRouterMethods(c, mappingMethods...))
 }
 
 // Include only when the Runmode is dev will generate router file in the router/auto.go from the controller

--- a/server/web/admin.go
+++ b/server/web/admin.go
@@ -112,13 +112,13 @@ func registerAdmin() error {
 			HttpServer: NewHttpServerWithCfg(BConfig),
 		}
 		// keep in mind that all data should be html escaped to avoid XSS attack
-		beeAdminApp.Router("/", c, SetRouterMethods(c, "get:AdminIndex"))
-		beeAdminApp.Router("/qps", c, SetRouterMethods(c, "get:QpsIndex"))
-		beeAdminApp.Router("/prof", c, SetRouterMethods(c, "get:ProfIndex"))
-		beeAdminApp.Router("/healthcheck", c, SetRouterMethods(c, "get:Healthcheck"))
-		beeAdminApp.Router("/task", c, SetRouterMethods(c, "get:TaskStatus"))
-		beeAdminApp.Router("/listconf", c, SetRouterMethods(c, "get:ListConf"))
-		beeAdminApp.Router("/metrics", c, SetRouterMethods(c, "get:PrometheusMetrics"))
+		beeAdminApp.Router("/", c, "get:AdminIndex")
+		beeAdminApp.Router("/qps", c, "get:QpsIndex")
+		beeAdminApp.Router("/prof", c, "get:ProfIndex")
+		beeAdminApp.Router("/healthcheck", c, "get:Healthcheck")
+		beeAdminApp.Router("/task", c, "get:TaskStatus")
+		beeAdminApp.Router("/listconf", c, "get:ListConf")
+		beeAdminApp.Router("/metrics", c, "get:PrometheusMetrics")
 
 		go beeAdminApp.Run()
 	}

--- a/server/web/flash_test.go
+++ b/server/web/flash_test.go
@@ -40,7 +40,7 @@ func TestFlashHeader(t *testing.T) {
 
 	// setup the handler
 	handler := NewControllerRegister()
-	handler.Add("/", &TestFlashController{}, SetRouterMethods(&TestFlashController{}, "get:TestWriteFlash"))
+	handler.Add("/", &TestFlashController{}, WithRouterMethods(&TestFlashController{}, "get:TestWriteFlash"))
 	handler.ServeHTTP(w, r)
 
 	// get the Set-Cookie value

--- a/server/web/namespace.go
+++ b/server/web/namespace.go
@@ -99,7 +99,7 @@ func (n *Namespace) Filter(action string, filter ...FilterFunc) *Namespace {
 // Router same as beego.Rourer
 // refer: https://godoc.org/github.com/beego/beego/v2#Router
 func (n *Namespace) Router(rootpath string, c ControllerInterface, mappingMethods ...string) *Namespace {
-	n.handlers.Add(rootpath, c, SetRouterMethods(c, mappingMethods...))
+	n.handlers.Add(rootpath, c, WithRouterMethods(c, mappingMethods...))
 	return n
 }
 

--- a/server/web/router.go
+++ b/server/web/router.go
@@ -121,19 +121,19 @@ type ControllerInfo struct {
 	sessionOn      bool
 }
 
-type ControllerOptions func(*ControllerInfo)
+type ControllerOption func(*ControllerInfo)
 
 func (c *ControllerInfo) GetPattern() string {
 	return c.pattern
 }
 
-func SetRouterMethods(ctrlInterface ControllerInterface, mappingMethod ...string) ControllerOptions {
+func WithRouterMethods(ctrlInterface ControllerInterface, mappingMethod ...string) ControllerOption {
 	return func(c *ControllerInfo) {
 		c.methods = parseMappingMethods(ctrlInterface, mappingMethod)
 	}
 }
 
-func SetRouterSessionOn(sessionOn bool) ControllerOptions {
+func WithRouterSessionOn(sessionOn bool) ControllerOption {
 	return func(c *ControllerInfo) {
 		c.sessionOn = sessionOn
 	}
@@ -186,7 +186,7 @@ func NewControllerRegisterWithCfg(cfg *Config) *ControllerRegister {
 //	Add("/api/delete",&RestController{},"delete:DeleteFood")
 //	Add("/api",&RestController{},"get,post:ApiFunc"
 //	Add("/simple",&SimpleController{},"get:GetFunc;post:PostFunc")
-func (p *ControllerRegister) Add(pattern string, c ControllerInterface, opts ...ControllerOptions) {
+func (p *ControllerRegister) Add(pattern string, c ControllerInterface, opts ...ControllerOption) {
 	p.addWithMethodParams(pattern, c, nil, opts...)
 }
 
@@ -239,7 +239,7 @@ func (p *ControllerRegister) addRouterForMethod(route *ControllerInfo) {
 	}
 }
 
-func (p *ControllerRegister) addWithMethodParams(pattern string, c ControllerInterface, methodParams []*param.MethodParam, opts ...ControllerOptions) {
+func (p *ControllerRegister) addWithMethodParams(pattern string, c ControllerInterface, methodParams []*param.MethodParam, opts ...ControllerOption) {
 	reflectVal := reflect.ValueOf(c)
 	t := reflect.Indirect(reflectVal).Type()
 
@@ -311,7 +311,7 @@ func (p *ControllerRegister) Include(cList ...ControllerInterface) {
 					p.InsertFilter(f.Pattern, f.Pos, f.Filter, WithReturnOnOutput(f.ReturnOnOutput), WithResetParams(f.ResetParams))
 				}
 
-				p.addWithMethodParams(a.Router, c, a.MethodParams, SetRouterMethods(c, strings.Join(a.AllowHTTPMethods, ",")+":"+a.Method))
+				p.addWithMethodParams(a.Router, c, a.MethodParams, WithRouterMethods(c, strings.Join(a.AllowHTTPMethods, ",")+":"+a.Method))
 			}
 		}
 	}

--- a/server/web/router_test.go
+++ b/server/web/router_test.go
@@ -97,7 +97,7 @@ func (jc *JSONController) Get() {
 
 func TestPrefixUrlFor(t *testing.T){
 	handler := NewControllerRegister()
-	handler.Add("/my/prefix/list", &PrefixTestController{}, "get:PrefixList")
+	handler.Add("/my/prefix/list", &PrefixTestController{}, WithRouterMethods(&PrefixTestController{}, "get:PrefixList"))
 
 	if a := handler.URLFor(`PrefixTestController.PrefixList`); a != `/my/prefix/list` {
 		logs.Info(a)
@@ -111,8 +111,8 @@ func TestPrefixUrlFor(t *testing.T){
 
 func TestUrlFor(t *testing.T) {
 	handler := NewControllerRegister()
-	handler.Add("/api/list", &TestController{}, SetRouterMethods(&TestController{}, "*:List"))
-	handler.Add("/person/:last/:first", &TestController{}, SetRouterMethods(&TestController{}, "*:Param"))
+	handler.Add("/api/list", &TestController{}, WithRouterMethods(&TestController{}, "*:List"))
+	handler.Add("/person/:last/:first", &TestController{}, WithRouterMethods(&TestController{}, "*:Param"))
 	if a := handler.URLFor("TestController.List"); a != "/api/list" {
 		logs.Info(a)
 		t.Errorf("TestController.List must equal to /api/list")
@@ -135,9 +135,9 @@ func TestUrlFor3(t *testing.T) {
 
 func TestUrlFor2(t *testing.T) {
 	handler := NewControllerRegister()
-	handler.Add("/v1/:v/cms_:id(.+)_:page(.+).html", &TestController{}, SetRouterMethods(&TestController{}, "*:List"))
-	handler.Add("/v1/:username/edit", &TestController{}, SetRouterMethods(&TestController{}, "get:GetURL"))
-	handler.Add("/v1/:v(.+)_cms/ttt_:id(.+)_:page(.+).html", &TestController{}, SetRouterMethods(&TestController{}, "*:Param"))
+	handler.Add("/v1/:v/cms_:id(.+)_:page(.+).html", &TestController{}, WithRouterMethods(&TestController{}, "*:List"))
+	handler.Add("/v1/:username/edit", &TestController{}, WithRouterMethods(&TestController{}, "get:GetURL"))
+	handler.Add("/v1/:v(.+)_cms/ttt_:id(.+)_:page(.+).html", &TestController{}, WithRouterMethods(&TestController{}, "*:Param"))
 	handler.Add("/:year:int/:month:int/:title/:entid", &TestController{})
 	if handler.URLFor("TestController.GetURL", ":username", "astaxie") != "/v1/astaxie/edit" {
 		logs.Info(handler.URLFor("TestController.GetURL"))
@@ -167,7 +167,7 @@ func TestUserFunc(t *testing.T) {
 	w := httptest.NewRecorder()
 
 	handler := NewControllerRegister()
-	handler.Add("/api/list", &TestController{}, SetRouterMethods(&TestController{}, "*:List"))
+	handler.Add("/api/list", &TestController{}, WithRouterMethods(&TestController{}, "*:List"))
 	handler.ServeHTTP(w, r)
 	if w.Body.String() != "i am list" {
 		t.Errorf("user define func can't run")
@@ -257,7 +257,7 @@ func TestRouteOk(t *testing.T) {
 	w := httptest.NewRecorder()
 
 	handler := NewControllerRegister()
-	handler.Add("/person/:last/:first", &TestController{}, SetRouterMethods(&TestController{}, "get:GetParams"))
+	handler.Add("/person/:last/:first", &TestController{}, WithRouterMethods(&TestController{}, "get:GetParams"))
 	handler.ServeHTTP(w, r)
 	body := w.Body.String()
 	if body != "anderson+thomas+kungfu" {
@@ -271,7 +271,7 @@ func TestManyRoute(t *testing.T) {
 	w := httptest.NewRecorder()
 
 	handler := NewControllerRegister()
-	handler.Add("/beego:id([0-9]+)-:page([0-9]+).html", &TestController{}, SetRouterMethods(&TestController{}, "get:GetManyRouter"))
+	handler.Add("/beego:id([0-9]+)-:page([0-9]+).html", &TestController{}, WithRouterMethods(&TestController{}, "get:GetManyRouter"))
 	handler.ServeHTTP(w, r)
 
 	body := w.Body.String()
@@ -288,7 +288,7 @@ func TestEmptyResponse(t *testing.T) {
 	w := httptest.NewRecorder()
 
 	handler := NewControllerRegister()
-	handler.Add("/beego-empty.html", &TestController{}, SetRouterMethods(&TestController{}, "get:GetEmptyBody"))
+	handler.Add("/beego-empty.html", &TestController{}, WithRouterMethods(&TestController{}, "get:GetEmptyBody"))
 	handler.ServeHTTP(w, r)
 
 	if body := w.Body.String(); body != "" {
@@ -783,8 +783,8 @@ func TestRouterSessionSet(t *testing.T) {
 	r, _ := http.NewRequest("GET", "/user", nil)
 	w := httptest.NewRecorder()
 	handler := NewControllerRegister()
-	handler.Add("/user", &TestController{}, SetRouterMethods(&TestController{}, "get:Get"),
-		SetRouterSessionOn(false))
+	handler.Add("/user", &TestController{}, WithRouterMethods(&TestController{}, "get:Get"),
+		WithRouterSessionOn(false))
 	handler.ServeHTTP(w, r)
 	if w.Header().Get("Set-Cookie") != "" {
 		t.Errorf("TestRotuerSessionSet failed")
@@ -794,8 +794,8 @@ func TestRouterSessionSet(t *testing.T) {
 	r, _ = http.NewRequest("GET", "/user", nil)
 	w = httptest.NewRecorder()
 	handler = NewControllerRegister()
-	handler.Add("/user", &TestController{}, SetRouterMethods(&TestController{}, "get:Get"),
-		SetRouterSessionOn(true))
+	handler.Add("/user", &TestController{}, WithRouterMethods(&TestController{}, "get:Get"),
+		WithRouterSessionOn(true))
 	handler.ServeHTTP(w, r)
 	if w.Header().Get("Set-Cookie") != "" {
 		t.Errorf("TestRotuerSessionSet failed")
@@ -809,8 +809,8 @@ func TestRouterSessionSet(t *testing.T) {
 	r, _ = http.NewRequest("GET", "/user", nil)
 	w = httptest.NewRecorder()
 	handler = NewControllerRegister()
-	handler.Add("/user", &TestController{}, SetRouterMethods(&TestController{}, "get:Get"),
-		SetRouterSessionOn(false))
+	handler.Add("/user", &TestController{}, WithRouterMethods(&TestController{}, "get:Get"),
+		WithRouterSessionOn(false))
 	handler.ServeHTTP(w, r)
 	if w.Header().Get("Set-Cookie") != "" {
 		t.Errorf("TestRotuerSessionSet failed")
@@ -820,8 +820,8 @@ func TestRouterSessionSet(t *testing.T) {
 	r, _ = http.NewRequest("GET", "/user", nil)
 	w = httptest.NewRecorder()
 	handler = NewControllerRegister()
-	handler.Add("/user", &TestController{}, SetRouterMethods(&TestController{}, "get:Get"),
-		SetRouterSessionOn(true))
+	handler.Add("/user", &TestController{}, WithRouterMethods(&TestController{}, "get:Get"),
+		WithRouterSessionOn(true))
 	handler.ServeHTTP(w, r)
 	if w.Header().Get("Set-Cookie") == "" {
 		t.Errorf("TestRotuerSessionSet failed")

--- a/server/web/server.go
+++ b/server/web/server.go
@@ -266,8 +266,12 @@ func (app *HttpServer) Run(addr string, mws ...MiddleWare) {
 }
 
 // Router see HttpServer.Router
-func Router(rootpath string, c ControllerInterface, opts ...ControllerOptions) *HttpServer {
-	return BeeApp.Router(rootpath, c, opts...)
+func Router(rootpath string, c ControllerInterface, mappingMethods ...string) *HttpServer {
+	return RouterWithOpts(rootpath, c, WithRouterMethods(c, mappingMethods...))
+}
+
+func RouterWithOpts(rootpath string, c ControllerInterface, opts ...ControllerOption) *HttpServer {
+	return BeeApp.RouterWithOpts(rootpath, c, opts...)
 }
 
 // Router adds a patterned controller handler to BeeApp.
@@ -286,7 +290,11 @@ func Router(rootpath string, c ControllerInterface, opts ...ControllerOptions) *
 //  beego.Router("/api/create",&RestController{},"post:CreateFood")
 //  beego.Router("/api/update",&RestController{},"put:UpdateFood")
 //  beego.Router("/api/delete",&RestController{},"delete:DeleteFood")
-func (app *HttpServer) Router(rootPath string, c ControllerInterface, opts ...ControllerOptions) *HttpServer {
+func (app *HttpServer) Router(rootPath string, c ControllerInterface, mappingMethods ...string) *HttpServer {
+	return app.RouterWithOpts(rootPath, c, WithRouterMethods(c, mappingMethods...))
+}
+
+func (app *HttpServer) RouterWithOpts(rootPath string, c ControllerInterface, opts ...ControllerOption) *HttpServer {
 	app.Handlers.Add(rootPath, c, opts...)
 	return app
 }

--- a/server/web/unregroute_test.go
+++ b/server/web/unregroute_test.go
@@ -75,9 +75,9 @@ func TestUnregisterFixedRouteRoot(t *testing.T) {
 	var method = "GET"
 
 	handler := NewControllerRegister()
-	handler.Add("/", &TestPreUnregController{}, SetRouterMethods(&TestPreUnregController{}, "get:GetFixedRoot"))
-	handler.Add("/level1", &TestPreUnregController{}, SetRouterMethods(&TestPreUnregController{}, "get:GetFixedLevel1"))
-	handler.Add("/level1/level2", &TestPreUnregController{}, SetRouterMethods(&TestPreUnregController{}, "get:GetFixedLevel2"))
+	handler.Add("/", &TestPreUnregController{}, WithRouterMethods(&TestPreUnregController{}, "get:GetFixedRoot"))
+	handler.Add("/level1", &TestPreUnregController{}, WithRouterMethods(&TestPreUnregController{}, "get:GetFixedLevel1"))
+	handler.Add("/level1/level2", &TestPreUnregController{}, WithRouterMethods(&TestPreUnregController{}, "get:GetFixedLevel2"))
 
 	// Test original root
 	testHelperFnContentCheck(t, handler, "Test original root",
@@ -96,7 +96,7 @@ func TestUnregisterFixedRouteRoot(t *testing.T) {
 
 	// Replace the root path TestPreUnregController action with the action from
 	// TestPostUnregController
-	handler.Add("/", &TestPostUnregController{}, SetRouterMethods(&TestPostUnregController{}, "get:GetFixedRoot"))
+	handler.Add("/", &TestPostUnregController{}, WithRouterMethods(&TestPostUnregController{}, "get:GetFixedRoot"))
 
 	// Test replacement root (expect change)
 	testHelperFnContentCheck(t, handler, "Test replacement root (expect change)", method, "/", contentRootReplacement)
@@ -117,9 +117,9 @@ func TestUnregisterFixedRouteLevel1(t *testing.T) {
 	var method = "GET"
 
 	handler := NewControllerRegister()
-	handler.Add("/", &TestPreUnregController{}, SetRouterMethods(&TestPreUnregController{}, "get:GetFixedRoot"))
-	handler.Add("/level1", &TestPreUnregController{}, SetRouterMethods(&TestPreUnregController{}, "get:GetFixedLevel1"))
-	handler.Add("/level1/level2", &TestPreUnregController{}, SetRouterMethods(&TestPreUnregController{}, "get:GetFixedLevel2"))
+	handler.Add("/", &TestPreUnregController{}, WithRouterMethods(&TestPreUnregController{}, "get:GetFixedRoot"))
+	handler.Add("/level1", &TestPreUnregController{}, WithRouterMethods(&TestPreUnregController{}, "get:GetFixedLevel1"))
+	handler.Add("/level1/level2", &TestPreUnregController{}, WithRouterMethods(&TestPreUnregController{}, "get:GetFixedLevel2"))
 
 	// Test original root
 	testHelperFnContentCheck(t, handler,
@@ -146,7 +146,7 @@ func TestUnregisterFixedRouteLevel1(t *testing.T) {
 
 	// Replace the "level1" path TestPreUnregController action with the action from
 	// TestPostUnregController
-	handler.Add("/level1", &TestPostUnregController{}, SetRouterMethods(&TestPostUnregController{}, "get:GetFixedLevel1"))
+	handler.Add("/level1", &TestPostUnregController{}, WithRouterMethods(&TestPostUnregController{}, "get:GetFixedLevel1"))
 
 	// Test replacement root (expect no change from the original)
 	testHelperFnContentCheck(t, handler, "Test replacement root (expect no change from the original)", method, "/", contentRootOriginal)
@@ -167,9 +167,9 @@ func TestUnregisterFixedRouteLevel2(t *testing.T) {
 	var method = "GET"
 
 	handler := NewControllerRegister()
-	handler.Add("/", &TestPreUnregController{}, SetRouterMethods(&TestPreUnregController{}, "get:GetFixedRoot"))
-	handler.Add("/level1", &TestPreUnregController{}, SetRouterMethods(&TestPreUnregController{}, "get:GetFixedLevel1"))
-	handler.Add("/level1/level2", &TestPreUnregController{}, SetRouterMethods(&TestPreUnregController{}, "get:GetFixedLevel2"))
+	handler.Add("/", &TestPreUnregController{}, WithRouterMethods(&TestPreUnregController{}, "get:GetFixedRoot"))
+	handler.Add("/level1", &TestPreUnregController{}, WithRouterMethods(&TestPreUnregController{}, "get:GetFixedLevel1"))
+	handler.Add("/level1/level2", &TestPreUnregController{}, WithRouterMethods(&TestPreUnregController{}, "get:GetFixedLevel2"))
 
 	// Test original root
 	testHelperFnContentCheck(t, handler,
@@ -196,7 +196,7 @@ func TestUnregisterFixedRouteLevel2(t *testing.T) {
 
 	// Replace the "/level1/level2" path TestPreUnregController action with the action from
 	// TestPostUnregController
-	handler.Add("/level1/level2", &TestPostUnregController{}, SetRouterMethods(&TestPostUnregController{}, "get:GetFixedLevel2"))
+	handler.Add("/level1/level2", &TestPostUnregController{}, WithRouterMethods(&TestPostUnregController{}, "get:GetFixedLevel2"))
 
 	// Test replacement root (expect no change from the original)
 	testHelperFnContentCheck(t, handler, "Test replacement root (expect no change from the original)", method, "/", contentRootOriginal)


### PR DESCRIPTION
PR #4318 introduce incompatible change, including server.go#Router, HttpServer#Router

I add two more method to keep compatible with current stable version.