### PR TITLE
Support for Postgres UUID type

### DIFF
--- a/client/orm/db_postgres.go
+++ b/client/orm/db_postgres.go
@@ -55,6 +55,7 @@ var postgresTypes = map[string]string{
 	"uint16":              `integer CHECK("%COL%" >= 0)`,
 	"uint32":              `bigint CHECK("%COL%" >= 0)`,
 	"uint64":              `bigint CHECK("%COL%" >= 0)`,
+	"uuid":                "uuid",
 	"float64":             "double precision",
 	"float64-decimal":     "numeric(%d, %d)",
 	"json":                "json",


### PR DESCRIPTION
Added support for PostgreSQL UUID data type.

[https://www.postgresql.org/docs/9.2/datatype-uuid.html](https://www.postgresql.org/docs/9.2/datatype-uuid.html)