### PR TITLE
Support RollbackUnlessCommit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Add sonar check and ignore test. [4432](https://github.com/beego/beego/pull/4432) [4433](https://github.com/beego/beego/pull/4433)
 - Update changlog.yml to check every PR to develop branch.[4427](https://github.com/beego/beego/pull/4427)
 - Fix 4396: Add context.param module into adapter. [4398](https://github.com/beego/beego/pull/4398)
+- Support `RollbackUnlessCommit` API. [4542](https://github.com/beego/beego/pull/4542)
 - Remove `duration` from prometheus labels. [4391](https://github.com/beego/beego/pull/4391)
 - Fix `unknown escape sequence` in generated code. [4385](https://github.com/beego/beego/pull/4385)
 - Using fixed name `commentRouter.go` as generated file name. [4385](https://github.com/beego/beego/pull/4385)

--- a/client/orm/db_alias.go
+++ b/client/orm/db_alias.go
@@ -232,6 +232,14 @@ func (t *TxDB) Rollback() error {
 	return t.tx.Rollback()
 }
 
+func (t *TxDB) RollbackUnlessCommit() error {
+	err := t.tx.Rollback()
+	if err != sql.ErrTxDone {
+		return err
+	}
+	return nil
+}
+
 var _ dbQuerier = new(TxDB)
 var _ txEnder = new(TxDB)
 

--- a/client/orm/filter_orm_decorator.go
+++ b/client/orm/filter_orm_decorator.go
@@ -503,6 +503,22 @@ func (f *filterOrmDecorator) Rollback() error {
 	return f.convertError(res[0])
 }
 
+func (f *filterOrmDecorator) RollbackUnlessCommit() error {
+	inv := &Invocation{
+		Method:      "RollbackUnlessCommit",
+		Args:        []interface{}{},
+		InsideTx:    f.insideTx,
+		TxStartTime: f.txStartTime,
+		TxName:      f.txName,
+		f: func(c context.Context) []interface{} {
+			err := f.TxCommitter.RollbackUnlessCommit()
+			return []interface{}{err}
+		},
+	}
+	res := f.root(context.Background(), inv)
+	return f.convertError(res[0])
+}
+
 func (f *filterOrmDecorator) convertError(v interface{}) error {
 	if v == nil {
 		return nil

--- a/client/orm/filter_orm_decorator_test.go
+++ b/client/orm/filter_orm_decorator_test.go
@@ -402,6 +402,10 @@ func (f *filterMockOrm) Rollback() error {
 	return errors.New("rollback")
 }
 
+func (f *filterMockOrm) RollbackUnlessCommit() error {
+	return errors.New("rollback unless commit")
+}
+
 func (f *filterMockOrm) DBStats() *sql.DBStats {
 	return &sql.DBStats{
 		MaxOpenConnections: -1,

--- a/client/orm/mock/mock_orm.go
+++ b/client/orm/mock/mock_orm.go
@@ -160,3 +160,8 @@ func MockCommit(err error) *Mock {
 func MockRollback(err error) *Mock {
 	return NewMock(NewSimpleCondition("", "Rollback"), []interface{}{err}, nil)
 }
+
+// MockRollbackUnlessCommit support RollbackUnlessCommit
+func MockRollbackUnlessCommit(err error) *Mock {
+	return NewMock(NewSimpleCondition("", "RollbackUnlessCommit"), []interface{}{err}, nil)
+}

--- a/client/orm/mock/mock_orm_test.go
+++ b/client/orm/mock/mock_orm_test.go
@@ -241,6 +241,19 @@ func TestTransactionRollback(t *testing.T) {
 	assert.Equal(t, mock, err)
 }
 
+func TestTransactionRollbackUnlessCommit(t *testing.T)  {
+	s := StartMock()
+	defer s.Clear()
+	mock := errors.New(mockErrorMsg)
+	s.Mock(MockRollbackUnlessCommit(mock))
+
+	//u := &User{}
+	o := orm.NewOrm()
+	txOrm, _ := o.Begin()
+	err := txOrm.RollbackUnlessCommit()
+	assert.Equal(t, mock, err)
+}
+
 func TestTransactionCommit(t *testing.T) {
 	s := StartMock()
 	defer s.Clear()

--- a/client/orm/orm.go
+++ b/client/orm/orm.go
@@ -593,6 +593,10 @@ func (t *txOrm) Rollback() error {
 	return t.db.(txEnder).Rollback()
 }
 
+func (t *txOrm) RollbackUnlessCommit() error {
+	return t.db.(txEnder).RollbackUnlessCommit()
+}
+
 // NewOrm create new orm
 func NewOrm() Ormer {
 	BootStrap() // execute only once

--- a/client/orm/orm_log.go
+++ b/client/orm/orm_log.go
@@ -206,6 +206,13 @@ func (d *dbQueryLog) Rollback() error {
 	return err
 }
 
+func (d *dbQueryLog) RollbackUnlessCommit() error {
+	a := time.Now()
+	err := d.db.(txEnder).RollbackUnlessCommit()
+	debugLogQueies(d.alias, "tx.RollbackUnlessCommit", "ROLLBACK UNLESS COMMIT", a, err)
+	return err
+}
+
 func (d *dbQueryLog) SetDB(db dbQuerier) {
 	d.db = db
 }

--- a/client/orm/types.go
+++ b/client/orm/types.go
@@ -110,9 +110,34 @@ type TxBeginner interface {
 }
 
 type TxCommitter interface {
+	txEnder
+}
+
+// transaction beginner
+type txer interface {
+	Begin() (*sql.Tx, error)
+	BeginTx(ctx context.Context, opts *sql.TxOptions) (*sql.Tx, error)
+}
+
+// transaction ending
+type txEnder interface {
 	Commit() error
 	Rollback() error
+
+	// RollbackUnlessCommit if the transaction has been committed, do nothing, or transaction will be rollback
+	// For example:
+	// ```go
+	//    txOrm := orm.Begin()
+	//    defer txOrm.RollbackUnlessCommit()
+	//    err := txOrm.Insert() // do something
+	//    if err != nil {
+	//       return err
+	//    }
+	//    txOrm.Commit()
+	// ```
+	RollbackUnlessCommit() error
 }
+
 
 // Data Manipulation Language
 type DML interface {
@@ -591,18 +616,6 @@ type dbQuerier interface {
 // 	Query(query string, args ...interface{}) (*sql.Rows, error)
 // 	QueryRow(query string, args ...interface{}) *sql.Row
 // }
-
-// transaction beginner
-type txer interface {
-	Begin() (*sql.Tx, error)
-	BeginTx(ctx context.Context, opts *sql.TxOptions) (*sql.Tx, error)
-}
-
-// transaction ending
-type txEnder interface {
-	Commit() error
-	Rollback() error
-}
 
 // base database struct
 type dbBaser interface {


### PR DESCRIPTION
In order to make handle transaction manually more easily, I provide a new API named `RollbackUnlessCommit`, it was inspired by `gorm` v1. And I think it could reduce such code:
```go
if err != nil {
   tx.Rollback()
   return err
}
```
I forget to call `Rollback` several times when I used beego Orm.
Now, I can write code looks like:
```go
tx := o.Begin()
defer tx.RollbackUnlessCommit()
```
Close #4428 