### PR TITLE
将操作数据库的错误进行返回

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 - fix: code quality issues [4513](https://github.com/beego/beego/pull/4513)
 - Optimize maligned structs to reduce memory foot-print [4525](https://github.com/beego/beego/pull/4525)
 - Feat: add token bucket ratelimit filter [4508](https://github.com/beego/beego/pull/4508)
+- Improve: Avoid ignoring mistakes that need attention [4548](https://github.com/beego/beego/pull/4548)
 
 
 

--- a/server/web/session/mysql/sess_mysql.go
+++ b/server/web/session/mysql/sess_mysql.go
@@ -150,6 +150,8 @@ func (mp *Provider) SessionRead(ctx context.Context, sid string) (session.Store,
 	if err == sql.ErrNoRows {
 		c.Exec("insert into "+TableName+"(`session_key`,`session_data`,`session_expiry`) values(?,?,?)",
 			sid, "", time.Now().Unix())
+	} else if err != nil {
+		return nil, err
 	}
 	var kv map[interface{}]interface{}
 	if len(sessiondata) == 0 {
@@ -189,7 +191,10 @@ func (mp *Provider) SessionRegenerate(ctx context.Context, oldsid, sid string) (
 	if err == sql.ErrNoRows {
 		c.Exec("insert into "+TableName+"(`session_key`,`session_data`,`session_expiry`) values(?,?,?)", oldsid, "", time.Now().Unix())
 	}
-	c.Exec("update "+TableName+" set `session_key`=? where session_key=?", sid, oldsid)
+	_, err = c.Exec("update "+TableName+" set `session_key`=? where session_key=?", sid, oldsid)
+	if err != nil {
+		return nil, err
+	}
 	var kv map[interface{}]interface{}
 	if len(sessiondata) == 0 {
 		kv = make(map[interface{}]interface{})


### PR DESCRIPTION
当操作数据库出现错误时，将 error 返回会比吞掉错误合适，便于使用者定位问题