### PR TITLE
Draft design: web mock module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # developing
+- Web mock and test support. [4565](https://github.com/beego/beego/pull/4565)
 - Error codes definition of cache module. [4493](https://github.com/beego/beego/pull/4493)
 - Remove generateCommentRoute http hook. Using `bee generate routers` commands instead.[4486](https://github.com/beego/beego/pull/4486) [bee PR 762](https://github.com/beego/bee/pull/762)
 - Fix: /abc.html/aaa match /abc/aaa. [4459](https://github.com/beego/beego/pull/4459)

--- a/server/web/mock/context.go
+++ b/server/web/mock/context.go
@@ -1,0 +1,27 @@
+// Copyright 2021 beego
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mock
+
+import (
+	beegoCtx "github.com/beego/beego/v2/server/web/context"
+	"net/http"
+)
+
+func NewMockContext(req *http.Request) (*beegoCtx.Context, *HttpResponse) {
+	ctx := beegoCtx.NewContext()
+	resp := NewMockHttpResponse()
+	ctx.Reset(resp, req)
+	return ctx, resp
+}

--- a/server/web/mock/context_test.go
+++ b/server/web/mock/context_test.go
@@ -1,0 +1,48 @@
+// Copyright 2021 beego
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mock
+
+import (
+	"bytes"
+	"fmt"
+	"github.com/beego/beego/v2/server/web"
+	"github.com/stretchr/testify/assert"
+	"net/http"
+	"testing"
+)
+
+type TestController struct {
+	web.Controller
+}
+
+func TestMockContext(t *testing.T) {
+	req, err := http.NewRequest("GET", "http://localhost:8080/hello?name=tom", bytes.NewReader([]byte{}))
+	assert.Nil(t, err)
+	ctx, resp := NewMockContext(req)
+	ctrl := &TestController{
+		Controller: web.Controller{
+			Ctx: ctx,
+		},
+	}
+	ctrl.HelloWorld()
+	result := resp.BodyToString()
+	assert.Equal(t, "name=tom", result)
+}
+
+// GET hello?name=XXX
+func (c *TestController) HelloWorld() {
+	name := c.GetString("name")
+	c.Ctx.WriteString(fmt.Sprintf("name=%s", name))
+}

--- a/server/web/mock/response.go
+++ b/server/web/mock/response.go
@@ -1,0 +1,61 @@
+// Copyright 2021 beego
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mock
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+// HttpResponse mock response, which should be used in tests
+type HttpResponse struct {
+	body       []byte
+	header     http.Header
+	StatusCode int
+}
+
+// NewMockHttpResponse you should only use this in your test code
+func NewMockHttpResponse() *HttpResponse {
+	return &HttpResponse{
+		body: make([]byte, 0),
+		header: make(http.Header),
+	}
+}
+
+// Header return headers
+func (m *HttpResponse) Header() http.Header {
+	return m.header
+}
+
+// Write append the body
+func (m *HttpResponse) Write(bytes []byte) (int, error) {
+	m.body = append(m.body, bytes...)
+	return len(bytes), nil
+}
+
+// WriteHeader set the status code
+func (m *HttpResponse) WriteHeader(statusCode int) {
+	m.StatusCode = statusCode
+}
+
+// JsonUnmarshal convert the body to object
+func (m *HttpResponse) JsonUnmarshal(value interface{}) error {
+	return json.Unmarshal(m.body, value)
+}
+
+// BodyToString return the body as the string
+func (m *HttpResponse) BodyToString() string {
+	return string(m.body)
+}


### PR DESCRIPTION
Assume that if someone want to test its `Controller`, he need to do two things:
1. Mock http request, he could use `http` lib to do this
2. got response: we must provide a "stub" response, so that users are able to read the response data from it.

So, here is a typical case:
```go
type TestController struct {
	web.Controller
}

func TestMockContext(t *testing.T) {
	req, err := http.NewRequest("GET", "http://localhost:8080/hello?name=tom", bytes.NewReader([]byte{}))
	assert.Nil(t, err)
	ctx, resp := NewMockContext(req)
	ctrl := &TestController{
		Controller: web.Controller{
			Ctx: ctx,
		},
	}
	ctrl.HelloWorld()
	result := resp.BodyToString()
	assert.Equal(t, "name=tom", result)
}

// GET hello?name=XXX
func (c *TestController) HelloWorld() {
	name := c.GetString("name")
	c.Ctx.WriteString(fmt.Sprintf("name=%s", name))
}
```
But I think `NewMockContext` return `ctx, resp` looks strange. `resp` is the stub. It contains all the response data after executing users' method.

But I can not find better definition.