### PR TITLE
Optimize AddAutoPrefix: only register one router in case insensitive mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,8 @@
 - Integration: DeepSource [4560](https://github.com/beego/beego/pull/4560)
 - Integration: Remove unnecessary function call [4577](https://github.com/beego/beego/pull/4577)
 - Feature issue #4402 finish router get example. [4416](https://github.com/beego/beego/pull/4416)
-- Proposal: Add Bind() method for web.Controller [4491](https://github.com/beego/beego/issues/4491)
+- Proposal: Add Bind() method for `web.Controller` [4491](https://github.com/beego/beego/issues/4579)
+- Optimize AddAutoPrefix: only register one router in case-insensitive mode. [4582](https://github.com/beego/beego/pull/4582)
 
 ## Fix Sonar
 - [4473](https://github.com/beego/beego/pull/4473)

--- a/server/web/router.go
+++ b/server/web/router.go
@@ -732,20 +732,30 @@ func (p *ControllerRegister) AddAutoPrefix(prefix string, c ControllerInterface)
 	ct := reflect.Indirect(reflectVal).Type()
 	controllerName := strings.TrimSuffix(ct.Name(), "Controller")
 	for i := 0; i < rt.NumMethod(); i++ {
-		if !utils.InSlice(rt.Method(i).Name, exceptMethod) {
-			pattern := path.Join(prefix, strings.ToLower(controllerName), strings.ToLower(rt.Method(i).Name), "*")
-			patternInit := path.Join(prefix, controllerName, rt.Method(i).Name, "*")
-			patternFix := path.Join(prefix, strings.ToLower(controllerName), strings.ToLower(rt.Method(i).Name))
-			patternFixInit := path.Join(prefix, controllerName, rt.Method(i).Name)
+		methodName := rt.Method(i).Name
+		if !utils.InSlice(methodName, exceptMethod) {
+			p.addAutoPrefixMethod(prefix, controllerName, methodName, ct)
+		}
+	}
+}
 
-			route := p.createBeegoRouter(ct, pattern)
-			route.methods = map[string]string{"*": rt.Method(i).Name}
-			for m := range HTTPMETHOD {
-				p.addToRouter(m, pattern, route)
-				p.addToRouter(m, patternInit, route)
-				p.addToRouter(m, patternFix, route)
-				p.addToRouter(m, patternFixInit, route)
-			}
+func (p *ControllerRegister) addAutoPrefixMethod(prefix, controllerName, methodName string, ctrl reflect.Type)  {
+	pattern := path.Join(prefix, strings.ToLower(controllerName), strings.ToLower(methodName), "*")
+	patternInit := path.Join(prefix, controllerName, methodName, "*")
+	patternFix := path.Join(prefix, strings.ToLower(controllerName), strings.ToLower(methodName))
+	patternFixInit := path.Join(prefix, controllerName, methodName)
+
+	route := p.createBeegoRouter(ctrl, pattern)
+	route.methods = map[string]string{"*": methodName}
+	for m := range HTTPMETHOD {
+
+		p.addToRouter(m, pattern, route)
+
+		// only case sensitive, we add three more routes
+		if p.cfg.RouterCaseSensitive {
+			p.addToRouter(m, patternInit, route)
+			p.addToRouter(m, patternFix, route)
+			p.addToRouter(m, patternFixInit, route)
 		}
 	}
 }


### PR DESCRIPTION
Last time I try to use `web.PrintTree()` to print all routers:
```go
func main() {
	web.AutoRouter(&UserController{})
	//web.Router()
	tree := web.PrintTree()
	methods := tree["Data"].(web.M)
	for k, v := range methods {
		fmt.Printf("%s => %v", k, v)
	}
	web.BConfig.RouterCaseSensitive = false
	web.Run()
}
```

I found that it prints many duplicate routers and then I find the reason. This PR partially fixed duplicate problem. And I may introduce new method to replace `PrintTree` to completely resolve this problem in the future. The data returned by `PrintTree` is unreadable. Let me think about how to improve it.