### PR TITLE
Fix 4590: Forget to check URL when FilterChain invoke next()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Fix 4480: log format incorrect. [4482](https://github.com/beego/beego/pull/4482)
 - Remove `duration` from prometheus labels. [4391](https://github.com/beego/beego/pull/4391)
 - Fix `unknown escape sequence` in generated code. [4385](https://github.com/beego/beego/pull/4385)
+- Fix 4590: Forget to check URL when FilterChain invoke `next()`. [4593](https://github.com/beego/beego/pull/4593)
 - Using fixed name `commentRouter.go` as generated file name. [4385](https://github.com/beego/beego/pull/4385)
 - Fix 4383: ORM Adapter produces panic when using orm.RegisterModelWithPrefix. [4386](https://github.com/beego/beego/pull/4386)
 - Fix 4444: panic when 404 not found. [4446](https://github.com/beego/beego/pull/4446)

--- a/server/web/filter_chain_test.go
+++ b/server/web/filter_chain_test.go
@@ -15,16 +15,18 @@
 package web
 
 import (
+	"github.com/beego/beego/v2/core/logs"
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 
 	"github.com/beego/beego/v2/server/web/context"
 )
 
-func TestControllerRegister_InsertFilterChain(t *testing.T) {
+func TestControllerRegisterInsertFilterChain(t *testing.T) {
 
 	InsertFilterChain("/*", func(next FilterFunc) FilterFunc {
 		return func(ctx *context.Context) {
@@ -45,4 +47,25 @@ func TestControllerRegister_InsertFilterChain(t *testing.T) {
 	BeeApp.Handlers.ServeHTTP(w, r)
 
 	assert.Equal(t, "filter-chain", w.Header().Get("filter"))
+}
+
+func TestFilterChainRouter(t *testing.T) {
+	InsertFilterChain("/app/hello1/*", func(next FilterFunc) FilterFunc {
+		return func(ctx *context.Context) {
+			logs.Info("aaa")
+			next(ctx)
+		}
+	})
+
+	InsertFilterChain("/app/*", func(next FilterFunc) FilterFunc {
+		return func(ctx *context.Context) {
+			start := time.Now()
+			ctx.Input.SetData("start", start)
+			logs.Info("start_time", start)
+			next(ctx)
+			logs.Info("run_time", time.Since(start).String())
+		}
+	})
+
+	Run()
 }

--- a/server/web/router.go
+++ b/server/web/router.go
@@ -486,7 +486,11 @@ func (p *ControllerRegister) InsertFilter(pattern string, pos int, filter Filter
 // }
 func (p *ControllerRegister) InsertFilterChain(pattern string, chain FilterChain, opts ...FilterOpt) {
 	root := p.chainRoot
-	filterFunc := chain(root.filterFunc)
+	//filterFunc := chain(root.filterFunc)
+	filterFunc := chain(func(ctx *beecontext.Context) {
+		var preFilterParams map[string]string
+		root.filter(ctx, p.getUrlPath(ctx), preFilterParams)
+	})
 	opts = append(opts, WithCaseSensitive(p.cfg.RouterCaseSensitive))
 	p.chainRoot = newFilterRouter(pattern, filterFunc, opts...)
 	p.chainRoot.next = root


### PR DESCRIPTION
Close #4590 

When the first filter match the url and then it invoke next, we should check URL again.

So we could not use `FilterChain` directly, we must wrap it. 