### PR TITLE
fix json marshal in http request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # developing
 
+- Add a custom option for whether to escape HTML special characters when processing http request parameters. [4701](https://github.com/beego/beego/pull/4701)
 - Always set the response status in the CustomAbort function. [4686](https://github.com/beego/beego/pull/4686)
 - Add template functions eq,lt to support uint and int compare. [4607](https://github.com/beego/beego/pull/4607)
 - Migrate tests to GitHub Actions. [4663](https://github.com/beego/beego/issues/4663)

--- a/client/httplib/httplib.go
+++ b/client/httplib/httplib.go
@@ -340,7 +340,7 @@ func (b *BeegoHTTPRequest) YAMLBody(obj interface{}) (*BeegoHTTPRequest, error) 
 // JSONBody adds the request raw body encoded in JSON.
 func (b *BeegoHTTPRequest) JSONBody(obj interface{}) (*BeegoHTTPRequest, error) {
 	if b.req.Body == nil && obj != nil {
-		byts, err := b.Marshal(obj)
+		byts, err := b.JSONMarshal(obj)
 		if err != nil {
 			return b, berror.Wrap(err, InvalidJSONBody, "obj could not be converted to JSON body")
 		}
@@ -351,7 +351,7 @@ func (b *BeegoHTTPRequest) JSONBody(obj interface{}) (*BeegoHTTPRequest, error) 
 	return b, nil
 }
 
-func (b *BeegoHTTPRequest) Marshal(obj interface{}) ([]byte, error) {
+func (b *BeegoHTTPRequest) JSONMarshal(obj interface{}) ([]byte, error) {
 	bf := bytes.NewBuffer([]byte{})
 	jsonEncoder := json.NewEncoder(bf)
 	jsonEncoder.SetEscapeHTML(b.setting.EscapeHTML)

--- a/client/httplib/httplib.go
+++ b/client/httplib/httplib.go
@@ -258,6 +258,12 @@ func (b *BeegoHTTPRequest) AddFilters(fcs ...FilterChain) *BeegoHTTPRequest {
 	return b
 }
 
+// SetEscapeHTML is used to set the flag whether escape HTML special characters during processing
+func (b *BeegoHTTPRequest) SetEscapeHTML(isEscape bool) *BeegoHTTPRequest {
+	b.setting.EscapeHTML = isEscape
+	return b
+}
+
 // Param adds query param in to request.
 // params build query string as ?key1=value1&key2=value2...
 func (b *BeegoHTTPRequest) Param(key, value string) *BeegoHTTPRequest {
@@ -334,7 +340,7 @@ func (b *BeegoHTTPRequest) YAMLBody(obj interface{}) (*BeegoHTTPRequest, error) 
 // JSONBody adds the request raw body encoded in JSON.
 func (b *BeegoHTTPRequest) JSONBody(obj interface{}) (*BeegoHTTPRequest, error) {
 	if b.req.Body == nil && obj != nil {
-		byts, err := json.Marshal(obj)
+		byts, err := b.Marshal(obj)
 		if err != nil {
 			return b, berror.Wrap(err, InvalidJSONBody, "obj could not be converted to JSON body")
 		}
@@ -343,6 +349,17 @@ func (b *BeegoHTTPRequest) JSONBody(obj interface{}) (*BeegoHTTPRequest, error) 
 		b.req.Header.Set(contentTypeKey, "application/json")
 	}
 	return b, nil
+}
+
+func (b *BeegoHTTPRequest) Marshal(obj interface{}) ([]byte, error) {
+	bf := bytes.NewBuffer([]byte{})
+	jsonEncoder := json.NewEncoder(bf)
+	jsonEncoder.SetEscapeHTML(b.setting.EscapeHTML)
+	err := jsonEncoder.Encode(obj)
+	if err != nil {
+		return nil, err
+	}
+	return bf.Bytes(), nil
 }
 
 func (b *BeegoHTTPRequest) buildURL(paramBody string) {

--- a/client/httplib/httplib_test.go
+++ b/client/httplib/httplib_test.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"fmt"
 	"io/ioutil"
 	"net"
 	"net/http"
@@ -434,4 +435,14 @@ func TestBeegoHTTPRequestXMLBody(t *testing.T) {
 
 // TODO
 func TestBeegoHTTPRequestResponseForValue(t *testing.T) {
+}
+
+func TestBeegoHTTPRequestMarshal(t *testing.T) {
+	req := Post("http://beego.me")
+	req.SetEscapeHTML(false)
+	body := map[string]interface{} {
+		"escape": "left&right",
+	}
+	b, _ := req.Marshal(body)
+	assert.Equal(t,fmt.Sprintf(`{"escape":"left&right"}%s`, "\n"), string(b))
 }

--- a/client/httplib/httplib_test.go
+++ b/client/httplib/httplib_test.go
@@ -437,12 +437,12 @@ func TestBeegoHTTPRequestXMLBody(t *testing.T) {
 func TestBeegoHTTPRequestResponseForValue(t *testing.T) {
 }
 
-func TestBeegoHTTPRequestMarshal(t *testing.T) {
+func TestBeegoHTTPRequestJSONMarshal(t *testing.T) {
 	req := Post("http://beego.me")
 	req.SetEscapeHTML(false)
 	body := map[string]interface{} {
 		"escape": "left&right",
 	}
-	b, _ := req.Marshal(body)
+	b, _ := req.JSONMarshal(body)
 	assert.Equal(t,fmt.Sprintf(`{"escape":"left&right"}%s`, "\n"), string(b))
 }

--- a/client/httplib/httplib_test.go
+++ b/client/httplib/httplib_test.go
@@ -440,9 +440,9 @@ func TestBeegoHTTPRequestResponseForValue(t *testing.T) {
 func TestBeegoHTTPRequestJSONMarshal(t *testing.T) {
 	req := Post("http://beego.me")
 	req.SetEscapeHTML(false)
-	body := map[string]interface{} {
+	body := map[string]interface{}{
 		"escape": "left&right",
 	}
 	b, _ := req.JSONMarshal(body)
-	assert.Equal(t,fmt.Sprintf(`{"escape":"left&right"}%s`, "\n"), string(b))
+	assert.Equal(t, fmt.Sprintf(`{"escape":"left&right"}%s`, "\n"), string(b))
 }

--- a/client/httplib/setting.go
+++ b/client/httplib/setting.go
@@ -37,6 +37,7 @@ type BeegoHTTPSettings struct {
 	Retries          int // if set to -1 means will retry forever
 	RetryDelay       time.Duration
 	FilterChains     []FilterChain
+	EscapeHTML       bool // if set to false means will not escape escape HTML special characters during processing, default true
 }
 
 // createDefaultCookie creates a global cookiejar to store cookies.
@@ -66,6 +67,7 @@ var defaultSetting = BeegoHTTPSettings{
 	ReadWriteTimeout: 60 * time.Second,
 	Gzip:             true,
 	FilterChains:     make([]FilterChain, 0, 4),
+	EscapeHTML:       true,
 }
 
 var (


### PR DESCRIPTION
The json.Marshal method will escape HTML special characters by default. 
When the value of a field of the request parameter contains these special characters, and the escape is not desired, the BeegoHTTPRequest.JSONBody method does not meet expectations for the processing of the request parameters.

E.g
```golang
body := map[string]interface{} {
	"escape": "left&right",
}
b, _ := json.Marshal(body)
fmt.Println(string(b))  // get '{"escape":"left\u0026right"}' but what is expected is '{"escape":"left&right"}'
```
