### PR TITLE
Add comments for BConfig, Rename RouterXXX functions and Define HandleFunc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@
 - Init exceptMethod by using reflection. [4583](https://github.com/beego/beego/pull/4583)
 - Deprecated BeeMap and replace all usage with `sync.map` [4616](https://github.com/beego/beego/pull/4616)
 - TaskManager support graceful shutdown [4635](https://github.com/beego/beego/pull/4635)
+- Add comments to `web.Config`, rename `RouterXXX` to `CtrlXXX`, define `HandleFunc` [4714](https://github.com/beego/beego/pull/4714)
 
 ## Fix Sonar
 

--- a/server/web/config.go
+++ b/server/web/config.go
@@ -35,96 +35,400 @@ import (
 // Config is the main struct for BConfig
 // TODO after supporting multiple servers, remove common config to somewhere else
 type Config struct {
+	// AppName
+	// @Description Application's name. You'd better set it because we use it to do some logging and tracing
+	// @Default beego
 	AppName             string // Application name
+	// RunMode
+	// @Description it's the same as environment. In general, we have different run modes.
+	// For example, the most common case is using dev, test, prod three environments
+	// when you are developing the application, you should set it as dev
+	// when you completed coding and want QA to test your code, you should deploy your application to test environment
+	// and the RunMode should be set as test
+	// when you completed all tests, you want to deploy it to prod, you should set it to prod
+	// You should never set RunMode="dev" when you deploy the application to prod
+	// because Beego will do more things which need Go SDK and other tools when it found out the RunMode="dev"
+	// @Default dev
 	RunMode             string // Running Mode: dev | prod
+
+	// RouterCaseSensitive
+	// @Description If it was true, it means that the router is case sensitive.
+	// For example, when you register a router with pattern "/hello",
+	// 1. If this is true, and the request URL is "/Hello", it won't match this pattern
+	// 2. If this is false and the request URL is "/Hello", it will match this pattern
+	// @Default true
 	RouterCaseSensitive bool
+	// RecoverPanic
+	// @Description if it was true, Beego will try to recover from panic when it serves your http request
+	// So you should notice that it doesn't mean that Beego will recover all panic cases.
+	// @Default true
 	RecoverPanic        bool
+	// CopyRequestBody
+	// @Description if it's true, Beego will copy the request body. But if the request body's size > MaxMemory,
+	// Beego will return 413 as http status
+	// If you are building RESTful API, please set it to true.
+	// And if you want to read data from request Body multiple times, please set it to true
+	// In general, if you don't meet any performance issue, you could set it to true
+	// @Default false
 	CopyRequestBody     bool
+	// EnableGzip
+	// @Description If it was true, Beego will try to compress data by using zip algorithm.
+	// But there are two points:
+	// 1. Only static resources will be compressed
+	// 2. Only those static resource which has the extension specified by StaticExtensionsToGzip will be compressed
+	// @Default false
 	EnableGzip          bool
+	// EnableErrorsShow
+	// @Description If it's true, Beego will show error message to page
+	// it will work with ErrorMaps which allows you register some error handler
+	// You may want to set it to false when application was deploy to prod environment
+	// because you may not want to expose your internal error msg to your users
+	// it's a little bit unsafe
+	// @Default true
 	EnableErrorsShow    bool
+	// EnableErrorsRender
+	// @Description If it's true, it will output the error msg as a page. It's similar to EnableErrorsShow
+	// And this configure item only work in dev run mode (see RunMode)
+	// @Default true
 	EnableErrorsRender  bool
+	// ServerName
+	// @Description server name. For example, in large scale system,
+	// you may want to deploy your application to several machines, so that each of them has a server name
+	// we suggest you'd better set value because Beego use this to output some DEBUG msg,
+	// or integrated with other tools such as tracing, metrics
+	// @Default
 	ServerName          string
+
+	// RecoverFunc
+	// @Description when Beego want to recover from panic, it will use this func as callback
+	// see RecoverPanic
+	// @Default defaultRecoverPanic
 	RecoverFunc         func(*context.Context, *Config)
-	// MaxMemory and MaxUploadSize are used to limit the request body
+	// @Description MaxMemory and MaxUploadSize are used to limit the request body
 	// if the request is not uploading file, MaxMemory is the max size of request body
 	// if the request is uploading file, MaxUploadSize is the max size of request body
+	// if CopyRequestBody is true, this value will be used as the threshold of request body
+	// see CopyRequestBody
+	// the default value is 1 << 26 (64MB)
+	// @Default 67108864
 	MaxMemory     int64
+	// MaxUploadSize
+	// @Description  MaxMemory and MaxUploadSize are used to limit the request body
+	// if the request is not uploading file, MaxMemory is the max size of request body
+	// if the request is uploading file, MaxUploadSize is the max size of request body
+	// the default value is 1 << 30 (1GB)
+	// @Default 1073741824
 	MaxUploadSize int64
+	// Listen
+	// @Description the configuration about socket or http protocol
 	Listen        Listen
+	// WebConfig
+	// @Description the configuration about Web
 	WebConfig     WebConfig
+	// LogConfig
+	// @Description log configuration
 	Log           LogConfig
 }
 
 // Listen holds for http and https related config
 type Listen struct {
-	Graceful          bool // Graceful means use graceful module to start the server
+	// Graceful
+	// @Description means use graceful module to start the server
+	// @Default false
+	Graceful          bool
+	// ListenTCP4
+	// @Description if it's true, means that Beego only work for TCP4
+	// please check net.Listen function
+	// In general, you should not set it to true
+	// @Default false
 	ListenTCP4        bool
+	// EnableHTTP
+	// @Description if it's true, Beego will accept HTTP request.
+	// But if you want to use HTTPS only, please set it to false
+	// see EnableHTTPS
+	// @Default true
 	EnableHTTP        bool
+	// AutoTLS
+	// @Description If it's true, Beego will use default value to initialize the TLS configure
+	// But those values could be override if you have custom value.
+	// see Domains, TLSCacheDir
+	// @Default false
 	AutoTLS           bool
+	// EnableHTTPS
+	// @Description If it's true, Beego will accept HTTPS request.
+	// Now, you'd better use HTTPS protocol on prod environment to get better security
+	// In prod, the best option is EnableHTTPS=true and EnableHTTP=false
+	// see EnableHTTP
+	// @Default false
 	EnableHTTPS       bool
+	// EnableMutualHTTPS
+	// @Description if it's true, Beego will handle requests on incoming mutual TLS connections
+	// see Server.ListenAndServeMutualTLS
+	// @Default false
 	EnableMutualHTTPS bool
+	// EnableAdmin
+	// @Description if it's true, Beego will provide admin service.
+	// You can visit the admin service via browser.
+	// The default port is 8088
+	// see AdminPort
+	// @Default false
 	EnableAdmin       bool
+	// EnableFcgi
+	// @Description
+	// @Default false
 	EnableFcgi        bool
-	EnableStdIo       bool // EnableStdIo works with EnableFcgi Use FCGI via standard I/O
+	// EnableStdIo
+	// @Description EnableStdIo works with EnableFcgi Use FCGI via standard I/O
+	// @Default false
+	EnableStdIo       bool
+	// ServerTimeOut
+	// @Description Beego use this as ReadTimeout and WriteTimeout
+	// The unit is second.
+	// see http.Server.ReadTimeout, WriteTimeout
+	// @Default 0
 	ServerTimeOut     int64
+	// HTTPAddr
+	// @Description Beego listen to this address when the application start up.
+	// @Default ""
 	HTTPAddr          string
+	// HTTPPort
+	// @Description Beego listen to this port
+	// you'd better change this value when you deploy to prod environment
+	// @Default 8080
 	HTTPPort          int
+	// Domains
+	// @Description Beego use this to configure TLS. Those domains are "white list" domain
+	// @Default []
 	Domains           []string
+	// TLSCacheDir
+	// @Description Beego use this as cache dir to store TLS cert data
+	// @Default ""
 	TLSCacheDir       string
+	// HTTPSAddr
+	// @Description Beego will listen to this address to accept HTTPS request
+	// see EnableHTTPS
+	// @Default ""
 	HTTPSAddr         string
+	// HTTPSPort
+	// @Description  Beego will listen to this port to accept HTTPS request
+	// @Default 10443
 	HTTPSPort         int
+	// HTTPSCertFile
+	// @Description Beego read this file as cert file
+	// When you are using HTTPS protocol, please configure it
+	// see HTTPSKeyFile
+	// @Default ""
 	HTTPSCertFile     string
+	// HTTPSKeyFile
+	// @Description Beego read this file as key file
+	// When you are using HTTPS protocol, please configure it
+	// see HTTPSCertFile
+	// @Default ""
 	HTTPSKeyFile      string
+	// TrustCaFile
+	// @Description Beego read this file as CA file
+	// @Default ""
 	TrustCaFile       string
+	// AdminAddr
+	// @Description Beego will listen to this address to provide admin service
+	// In general, it should be the same with your application address, HTTPAddr or HTTPSAddr
+	// @Default ""
 	AdminAddr         string
+	// AdminPort
+	// @Description  Beego will listen to this port to provide admin service
+	// @Default 8088
 	AdminPort         int
+	// @Description Beego use this tls.ClientAuthType to initialize TLS connection
+	// The default value is tls.RequireAndVerifyClientCert
+	// @Default 4
 	ClientAuth        int
 }
 
 // WebConfig holds web related config
 type WebConfig struct {
+	// AutoRender
+	// @Description If it's true, Beego will render the page based on your template and data
+	// In general, keep it as true.
+	// But if you are building RESTFul API and you don't have any page,
+	// you can set it to false
+	// @Default true
 	AutoRender             bool
+	// Deprecated: Beego didn't use it anymore
 	EnableDocs             bool
+	// EnableXSRF
+	// @Description If it's true, Beego will help to provide XSRF support
+	// But you should notice that, now Beego only work for HTTPS protocol with XSRF
+	// because it's not safe if using HTTP protocol
+	// And, the cookie storing XSRF token has two more flags HttpOnly and Secure
+	// It means that you must use HTTPS protocol and you can not read the token from JS script
+	// This is completed different from Beego 1.x because we got many security reports
+	// And if you are in dev environment, you could set it to false
+	// @Default false
 	EnableXSRF             bool
+	// DirectoryIndex
+	// @Description When Beego serves static resources request, it will look up the file.
+	// If the file is directory, Beego will try to find the index.html as the response
+	// But if the index.html is not exist or it's a directory,
+	// Beego will return 403 response if DirectoryIndex is **false**
+	// @Default false
 	DirectoryIndex         bool
+	// FlashName
+	// @Description the cookie's name when Beego try to store the flash data into cookie
+	// @Default BEEGO_FLASH
 	FlashName              string
+	// FlashSeparator
+	// @Description When Beego read flash data from request, it uses this as the separator
+	// @Default BEEGOFLASH
 	FlashSeparator         string
+	// StaticDir
+	// @Description Beego uses this as static resources' root directory.
+	// It means that Beego will try to search static resource from this start point
+	// It's a map, the key is the path and the value is the directory
+	// For example, the default value is /static => static,
+	// which means that when Beego got a request with path /static/xxx
+	// Beego will try to find the resource from static directory
+	// @Default /static => static
 	StaticDir              map[string]string
+	// StaticExtensionsToGzip
+	// @Description The static resources with those extension wille be compressed if EnableGzip is true
+	// @Default [".css", ".js" ]
 	StaticExtensionsToGzip []string
+	// StaticCacheFileSize
+	// @Description If the size of static resource < StaticCacheFileSize, Beego will try to handle it by itself,
+	// it means that Beego will compressed the file data (if enable) and cache this file.
+	// But if the file size > StaticCacheFileSize, Beego just simply delegate the request to http.ServeFile
+	// the default value is 100KB.
+	// the max memory size of caching static files is StaticCacheFileSize * StaticCacheFileNum
+	// see StaticCacheFileNum
+	// @Default 102400
 	StaticCacheFileSize    int
+	// StaticCacheFileNum
+	// @Description Beego use it to control the memory usage of caching static resource file
+	// If the caching files > StaticCacheFileNum, Beego use LRU algorithm to remove caching file
+	// the max memory size of caching static files is StaticCacheFileSize * StaticCacheFileNum
+	// see StaticCacheFileSize
+	// @Default 1000
 	StaticCacheFileNum     int
+	// TemplateLeft
+	// @Description Beego use this to render page
+	// see TemplateRight
+	// @Default {{
 	TemplateLeft           string
+	// TemplateRight
+	// @Description Beego use this to render page
+	// see TemplateLeft
+	// @Default }}
 	TemplateRight          string
+	// ViewsPath
+	// @Description The directory of Beego application storing template
+	// @Default views
 	ViewsPath              string
+	// CommentRouterPath
+	// @Description Beego scans this directory and its sub directory to generate router
+	// Beego only scans this directory when it's in dev environment
+	// @Default controllers
 	CommentRouterPath      string
+	// XSRFKey
+	// @Description the name of cookie storing XSRF token
+	// see EnableXSRF
+	// @Default beegoxsrf
 	XSRFKey                string
+	// XSRFExpire
+	// @Description the expiration time of XSRF token cookie
+	// second
+	// @Default 0
 	XSRFExpire             int
+	// @Description session related config
 	Session                SessionConfig
 }
 
 // SessionConfig holds session related config
 type SessionConfig struct {
+	// SessionOn
+	// @Description if it's true, Beego will auto manage session
+	// @Default false
 	SessionOn                    bool
+	// SessionAutoSetCookie
+	// @Description if it's true, Beego will put the session token into cookie too
+	// @Default true
 	SessionAutoSetCookie         bool
-	SessionDisableHTTPOnly       bool // used to allow for cross domain cookies/javascript cookies.
-	SessionEnableSidInHTTPHeader bool // enable store/get the sessionId into/from http headers
-	SessionEnableSidInURLQuery   bool // enable get the sessionId from Url Query params
+	// SessionDisableHTTPOnly
+	// @Description used to allow for cross domain cookies/javascript cookies
+	// In general, you should not set it to true unless you understand the risk
+	// @Default false
+	SessionDisableHTTPOnly       bool
+	// SessionEnableSidInHTTPHeader
+	// @Description enable store/get the sessionId into/from http headers
+	// @Default false
+	SessionEnableSidInHTTPHeader bool
+	// SessionEnableSidInURLQuery
+	// @Description enable get the sessionId from Url Query params
+	// @Default false
+	SessionEnableSidInURLQuery   bool
+	// SessionProvider
+	// @Description session provider's name.
+	// You should confirm that this provider has been register via session.Register method
+	// the default value is memory. This is not suitable for distributed system
+	// @Default memory
 	SessionProvider              string
+	// SessionName
+	// @Description If SessionAutoSetCookie is true, we use this value as the cookie's name
+	// @Default beegosessionID
 	SessionName                  string
+	// SessionGCMaxLifetime
+	// @Description Beego will GC session to clean useless session.
+	// unit: second
+	// @Default 3600
 	SessionGCMaxLifetime         int64
+	// SessionProviderConfig
+	// @Description the config of session provider
+	// see SessionProvider
+	// you should read the document of session provider to learn how to set this value
+	// @Default ""
 	SessionProviderConfig        string
+	// SessionCookieLifeTime
+	// @Description If SessionAutoSetCookie is true,
+	// we use this value as the expiration time and max age of the cookie
+	// unit second
+	// @Default 0
 	SessionCookieLifeTime        int
+	// SessionDomain
+	// @Description If SessionAutoSetCookie is true, we use this value as the cookie's domain
+	// @Default ""
 	SessionDomain                string
+	// SessionNameInHTTPHeader
+	// @Description if SessionEnableSidInHTTPHeader is true, this value will be used as the http header
+	// @Default Beegosessionid
 	SessionNameInHTTPHeader      string
+	// SessionCookieSameSite
+	// @Description If SessionAutoSetCookie is true, we use this value as the cookie's same site policy
+	// the default value is http.SameSiteDefaultMode
+	// @Default 1
 	SessionCookieSameSite        http.SameSite
 }
 
 // LogConfig holds Log related config
 type LogConfig struct {
+	// AccessLogs
+	// @Description If it's true, Beego will log the HTTP request info
+	// @Default false
 	AccessLogs       bool
-	EnableStaticLogs bool // log static files requests default: false
+	// EnableStaticLogs
+	// @Description log static files requests
+	// @Default false
+	EnableStaticLogs bool
+	// FileLineNum
+	// @Description if it's true, it will log the line number
+	// @Default true
 	FileLineNum      bool
-	AccessLogsFormat string            // access log format: JSON_FORMAT, APACHE_FORMAT or empty string
+	// AccessLogsFormat
+	// @Description access log format: JSON_FORMAT, APACHE_FORMAT or empty string
+	// @Default APACHE_FORMAT
+	AccessLogsFormat string
+	// Outputs
+	// @Description the destination of access log
+	// the key is log adapter and the value is adapter's configure
+	// @Default "console" => ""
 	Outputs          map[string]string // Store Adaptor : config
 }
 

--- a/server/web/config.go
+++ b/server/web/config.go
@@ -38,7 +38,7 @@ type Config struct {
 	// AppName
 	// @Description Application's name. You'd better set it because we use it to do some logging and tracing
 	// @Default beego
-	AppName             string // Application name
+	AppName string // Application name
 	// RunMode
 	// @Description it's the same as environment. In general, we have different run modes.
 	// For example, the most common case is using dev, test, prod three environments
@@ -49,7 +49,7 @@ type Config struct {
 	// You should never set RunMode="dev" when you deploy the application to prod
 	// because Beego will do more things which need Go SDK and other tools when it found out the RunMode="dev"
 	// @Default dev
-	RunMode             string // Running Mode: dev | prod
+	RunMode string // Running Mode: dev | prod
 
 	// RouterCaseSensitive
 	// @Description If it was true, it means that the router is case sensitive.
@@ -62,7 +62,7 @@ type Config struct {
 	// @Description if it was true, Beego will try to recover from panic when it serves your http request
 	// So you should notice that it doesn't mean that Beego will recover all panic cases.
 	// @Default true
-	RecoverPanic        bool
+	RecoverPanic bool
 	// CopyRequestBody
 	// @Description if it's true, Beego will copy the request body. But if the request body's size > MaxMemory,
 	// Beego will return 413 as http status
@@ -70,14 +70,14 @@ type Config struct {
 	// And if you want to read data from request Body multiple times, please set it to true
 	// In general, if you don't meet any performance issue, you could set it to true
 	// @Default false
-	CopyRequestBody     bool
+	CopyRequestBody bool
 	// EnableGzip
 	// @Description If it was true, Beego will try to compress data by using zip algorithm.
 	// But there are two points:
 	// 1. Only static resources will be compressed
 	// 2. Only those static resource which has the extension specified by StaticExtensionsToGzip will be compressed
 	// @Default false
-	EnableGzip          bool
+	EnableGzip bool
 	// EnableErrorsShow
 	// @Description If it's true, Beego will show error message to page
 	// it will work with ErrorMaps which allows you register some error handler
@@ -85,25 +85,25 @@ type Config struct {
 	// because you may not want to expose your internal error msg to your users
 	// it's a little bit unsafe
 	// @Default true
-	EnableErrorsShow    bool
+	EnableErrorsShow bool
 	// EnableErrorsRender
 	// @Description If it's true, it will output the error msg as a page. It's similar to EnableErrorsShow
 	// And this configure item only work in dev run mode (see RunMode)
 	// @Default true
-	EnableErrorsRender  bool
+	EnableErrorsRender bool
 	// ServerName
 	// @Description server name. For example, in large scale system,
 	// you may want to deploy your application to several machines, so that each of them has a server name
 	// we suggest you'd better set value because Beego use this to output some DEBUG msg,
 	// or integrated with other tools such as tracing, metrics
 	// @Default
-	ServerName          string
+	ServerName string
 
 	// RecoverFunc
 	// @Description when Beego want to recover from panic, it will use this func as callback
 	// see RecoverPanic
 	// @Default defaultRecoverPanic
-	RecoverFunc         func(*context.Context, *Config)
+	RecoverFunc func(*context.Context, *Config)
 	// @Description MaxMemory and MaxUploadSize are used to limit the request body
 	// if the request is not uploading file, MaxMemory is the max size of request body
 	// if the request is uploading file, MaxUploadSize is the max size of request body
@@ -111,7 +111,7 @@ type Config struct {
 	// see CopyRequestBody
 	// the default value is 1 << 26 (64MB)
 	// @Default 67108864
-	MaxMemory     int64
+	MaxMemory int64
 	// MaxUploadSize
 	// @Description  MaxMemory and MaxUploadSize are used to limit the request body
 	// if the request is not uploading file, MaxMemory is the max size of request body
@@ -121,13 +121,13 @@ type Config struct {
 	MaxUploadSize int64
 	// Listen
 	// @Description the configuration about socket or http protocol
-	Listen        Listen
+	Listen Listen
 	// WebConfig
 	// @Description the configuration about Web
-	WebConfig     WebConfig
+	WebConfig WebConfig
 	// LogConfig
 	// @Description log configuration
-	Log           LogConfig
+	Log LogConfig
 }
 
 // Listen holds for http and https related config
@@ -135,32 +135,32 @@ type Listen struct {
 	// Graceful
 	// @Description means use graceful module to start the server
 	// @Default false
-	Graceful          bool
+	Graceful bool
 	// ListenTCP4
 	// @Description if it's true, means that Beego only work for TCP4
 	// please check net.Listen function
 	// In general, you should not set it to true
 	// @Default false
-	ListenTCP4        bool
+	ListenTCP4 bool
 	// EnableHTTP
 	// @Description if it's true, Beego will accept HTTP request.
 	// But if you want to use HTTPS only, please set it to false
 	// see EnableHTTPS
 	// @Default true
-	EnableHTTP        bool
+	EnableHTTP bool
 	// AutoTLS
 	// @Description If it's true, Beego will use default value to initialize the TLS configure
 	// But those values could be override if you have custom value.
 	// see Domains, TLSCacheDir
 	// @Default false
-	AutoTLS           bool
+	AutoTLS bool
 	// EnableHTTPS
 	// @Description If it's true, Beego will accept HTTPS request.
 	// Now, you'd better use HTTPS protocol on prod environment to get better security
 	// In prod, the best option is EnableHTTPS=true and EnableHTTP=false
 	// see EnableHTTP
 	// @Default false
-	EnableHTTPS       bool
+	EnableHTTPS bool
 	// EnableMutualHTTPS
 	// @Description if it's true, Beego will handle requests on incoming mutual TLS connections
 	// see Server.ListenAndServeMutualTLS
@@ -172,76 +172,76 @@ type Listen struct {
 	// The default port is 8088
 	// see AdminPort
 	// @Default false
-	EnableAdmin       bool
+	EnableAdmin bool
 	// EnableFcgi
 	// @Description
 	// @Default false
-	EnableFcgi        bool
+	EnableFcgi bool
 	// EnableStdIo
 	// @Description EnableStdIo works with EnableFcgi Use FCGI via standard I/O
 	// @Default false
-	EnableStdIo       bool
+	EnableStdIo bool
 	// ServerTimeOut
 	// @Description Beego use this as ReadTimeout and WriteTimeout
 	// The unit is second.
 	// see http.Server.ReadTimeout, WriteTimeout
 	// @Default 0
-	ServerTimeOut     int64
+	ServerTimeOut int64
 	// HTTPAddr
 	// @Description Beego listen to this address when the application start up.
 	// @Default ""
-	HTTPAddr          string
+	HTTPAddr string
 	// HTTPPort
 	// @Description Beego listen to this port
 	// you'd better change this value when you deploy to prod environment
 	// @Default 8080
-	HTTPPort          int
+	HTTPPort int
 	// Domains
 	// @Description Beego use this to configure TLS. Those domains are "white list" domain
 	// @Default []
-	Domains           []string
+	Domains []string
 	// TLSCacheDir
 	// @Description Beego use this as cache dir to store TLS cert data
 	// @Default ""
-	TLSCacheDir       string
+	TLSCacheDir string
 	// HTTPSAddr
 	// @Description Beego will listen to this address to accept HTTPS request
 	// see EnableHTTPS
 	// @Default ""
-	HTTPSAddr         string
+	HTTPSAddr string
 	// HTTPSPort
 	// @Description  Beego will listen to this port to accept HTTPS request
 	// @Default 10443
-	HTTPSPort         int
+	HTTPSPort int
 	// HTTPSCertFile
 	// @Description Beego read this file as cert file
 	// When you are using HTTPS protocol, please configure it
 	// see HTTPSKeyFile
 	// @Default ""
-	HTTPSCertFile     string
+	HTTPSCertFile string
 	// HTTPSKeyFile
 	// @Description Beego read this file as key file
 	// When you are using HTTPS protocol, please configure it
 	// see HTTPSCertFile
 	// @Default ""
-	HTTPSKeyFile      string
+	HTTPSKeyFile string
 	// TrustCaFile
 	// @Description Beego read this file as CA file
 	// @Default ""
-	TrustCaFile       string
+	TrustCaFile string
 	// AdminAddr
 	// @Description Beego will listen to this address to provide admin service
 	// In general, it should be the same with your application address, HTTPAddr or HTTPSAddr
 	// @Default ""
-	AdminAddr         string
+	AdminAddr string
 	// AdminPort
 	// @Description  Beego will listen to this port to provide admin service
 	// @Default 8088
-	AdminPort         int
+	AdminPort int
 	// @Description Beego use this tls.ClientAuthType to initialize TLS connection
 	// The default value is tls.RequireAndVerifyClientCert
 	// @Default 4
-	ClientAuth        int
+	ClientAuth int
 }
 
 // WebConfig holds web related config
@@ -252,9 +252,9 @@ type WebConfig struct {
 	// But if you are building RESTFul API and you don't have any page,
 	// you can set it to false
 	// @Default true
-	AutoRender             bool
+	AutoRender bool
 	// Deprecated: Beego didn't use it anymore
-	EnableDocs             bool
+	EnableDocs bool
 	// EnableXSRF
 	// @Description If it's true, Beego will help to provide XSRF support
 	// But you should notice that, now Beego only work for HTTPS protocol with XSRF
@@ -264,22 +264,22 @@ type WebConfig struct {
 	// This is completed different from Beego 1.x because we got many security reports
 	// And if you are in dev environment, you could set it to false
 	// @Default false
-	EnableXSRF             bool
+	EnableXSRF bool
 	// DirectoryIndex
 	// @Description When Beego serves static resources request, it will look up the file.
 	// If the file is directory, Beego will try to find the index.html as the response
 	// But if the index.html is not exist or it's a directory,
 	// Beego will return 403 response if DirectoryIndex is **false**
 	// @Default false
-	DirectoryIndex         bool
+	DirectoryIndex bool
 	// FlashName
 	// @Description the cookie's name when Beego try to store the flash data into cookie
 	// @Default BEEGO_FLASH
-	FlashName              string
+	FlashName string
 	// FlashSeparator
 	// @Description When Beego read flash data from request, it uses this as the separator
 	// @Default BEEGOFLASH
-	FlashSeparator         string
+	FlashSeparator string
 	// StaticDir
 	// @Description Beego uses this as static resources' root directory.
 	// It means that Beego will try to search static resource from this start point
@@ -288,9 +288,9 @@ type WebConfig struct {
 	// which means that when Beego got a request with path /static/xxx
 	// Beego will try to find the resource from static directory
 	// @Default /static => static
-	StaticDir              map[string]string
+	StaticDir map[string]string
 	// StaticExtensionsToGzip
-	// @Description The static resources with those extension wille be compressed if EnableGzip is true
+	// @Description The static resources with those extension will be compressed if EnableGzip is true
 	// @Default [".css", ".js" ]
 	StaticExtensionsToGzip []string
 	// StaticCacheFileSize
@@ -301,45 +301,45 @@ type WebConfig struct {
 	// the max memory size of caching static files is StaticCacheFileSize * StaticCacheFileNum
 	// see StaticCacheFileNum
 	// @Default 102400
-	StaticCacheFileSize    int
+	StaticCacheFileSize int
 	// StaticCacheFileNum
 	// @Description Beego use it to control the memory usage of caching static resource file
 	// If the caching files > StaticCacheFileNum, Beego use LRU algorithm to remove caching file
 	// the max memory size of caching static files is StaticCacheFileSize * StaticCacheFileNum
 	// see StaticCacheFileSize
 	// @Default 1000
-	StaticCacheFileNum     int
+	StaticCacheFileNum int
 	// TemplateLeft
 	// @Description Beego use this to render page
 	// see TemplateRight
 	// @Default {{
-	TemplateLeft           string
+	TemplateLeft string
 	// TemplateRight
 	// @Description Beego use this to render page
 	// see TemplateLeft
 	// @Default }}
-	TemplateRight          string
+	TemplateRight string
 	// ViewsPath
 	// @Description The directory of Beego application storing template
 	// @Default views
-	ViewsPath              string
+	ViewsPath string
 	// CommentRouterPath
 	// @Description Beego scans this directory and its sub directory to generate router
 	// Beego only scans this directory when it's in dev environment
 	// @Default controllers
-	CommentRouterPath      string
+	CommentRouterPath string
 	// XSRFKey
 	// @Description the name of cookie storing XSRF token
 	// see EnableXSRF
 	// @Default beegoxsrf
-	XSRFKey                string
+	XSRFKey string
 	// XSRFExpire
 	// @Description the expiration time of XSRF token cookie
 	// second
 	// @Default 0
-	XSRFExpire             int
+	XSRFExpire int
 	// @Description session related config
-	Session                SessionConfig
+	Session SessionConfig
 }
 
 // SessionConfig holds session related config
@@ -347,16 +347,16 @@ type SessionConfig struct {
 	// SessionOn
 	// @Description if it's true, Beego will auto manage session
 	// @Default false
-	SessionOn                    bool
+	SessionOn bool
 	// SessionAutoSetCookie
 	// @Description if it's true, Beego will put the session token into cookie too
 	// @Default true
-	SessionAutoSetCookie         bool
+	SessionAutoSetCookie bool
 	// SessionDisableHTTPOnly
 	// @Description used to allow for cross domain cookies/javascript cookies
 	// In general, you should not set it to true unless you understand the risk
 	// @Default false
-	SessionDisableHTTPOnly       bool
+	SessionDisableHTTPOnly bool
 	// SessionEnableSidInHTTPHeader
 	// @Description enable store/get the sessionId into/from http headers
 	// @Default false
@@ -364,47 +364,47 @@ type SessionConfig struct {
 	// SessionEnableSidInURLQuery
 	// @Description enable get the sessionId from Url Query params
 	// @Default false
-	SessionEnableSidInURLQuery   bool
+	SessionEnableSidInURLQuery bool
 	// SessionProvider
 	// @Description session provider's name.
 	// You should confirm that this provider has been register via session.Register method
 	// the default value is memory. This is not suitable for distributed system
 	// @Default memory
-	SessionProvider              string
+	SessionProvider string
 	// SessionName
 	// @Description If SessionAutoSetCookie is true, we use this value as the cookie's name
 	// @Default beegosessionID
-	SessionName                  string
+	SessionName string
 	// SessionGCMaxLifetime
 	// @Description Beego will GC session to clean useless session.
 	// unit: second
 	// @Default 3600
-	SessionGCMaxLifetime         int64
+	SessionGCMaxLifetime int64
 	// SessionProviderConfig
 	// @Description the config of session provider
 	// see SessionProvider
 	// you should read the document of session provider to learn how to set this value
 	// @Default ""
-	SessionProviderConfig        string
+	SessionProviderConfig string
 	// SessionCookieLifeTime
 	// @Description If SessionAutoSetCookie is true,
 	// we use this value as the expiration time and max age of the cookie
 	// unit second
 	// @Default 0
-	SessionCookieLifeTime        int
+	SessionCookieLifeTime int
 	// SessionDomain
 	// @Description If SessionAutoSetCookie is true, we use this value as the cookie's domain
 	// @Default ""
-	SessionDomain                string
+	SessionDomain string
 	// SessionNameInHTTPHeader
 	// @Description if SessionEnableSidInHTTPHeader is true, this value will be used as the http header
 	// @Default Beegosessionid
-	SessionNameInHTTPHeader      string
+	SessionNameInHTTPHeader string
 	// SessionCookieSameSite
 	// @Description If SessionAutoSetCookie is true, we use this value as the cookie's same site policy
 	// the default value is http.SameSiteDefaultMode
 	// @Default 1
-	SessionCookieSameSite        http.SameSite
+	SessionCookieSameSite http.SameSite
 }
 
 // LogConfig holds Log related config
@@ -412,7 +412,7 @@ type LogConfig struct {
 	// AccessLogs
 	// @Description If it's true, Beego will log the HTTP request info
 	// @Default false
-	AccessLogs       bool
+	AccessLogs bool
 	// EnableStaticLogs
 	// @Description log static files requests
 	// @Default false
@@ -420,7 +420,7 @@ type LogConfig struct {
 	// FileLineNum
 	// @Description if it's true, it will log the line number
 	// @Default true
-	FileLineNum      bool
+	FileLineNum bool
 	// AccessLogsFormat
 	// @Description access log format: JSON_FORMAT, APACHE_FORMAT or empty string
 	// @Default APACHE_FORMAT
@@ -429,7 +429,7 @@ type LogConfig struct {
 	// @Description the destination of access log
 	// the key is log adapter and the value is adapter's configure
 	// @Default "console" => ""
-	Outputs          map[string]string // Store Adaptor : config
+	Outputs map[string]string // Store Adaptor : config
 }
 
 var (

--- a/server/web/config_test.go
+++ b/server/web/config_test.go
@@ -32,6 +32,10 @@ func TestDefaults(t *testing.T) {
 	}
 }
 
+func TestLoadAppConfig(t *testing.T) {
+	println(1 << 30)
+}
+
 func TestAssignConfig_01(t *testing.T) {
 	_BConfig := &Config{}
 	_BConfig.AppName = "beego_test"

--- a/server/web/controller.go
+++ b/server/web/controller.go
@@ -247,7 +247,7 @@ func (c *Controller) URLMapping() {}
 func (c *Controller) Bind(obj interface{}) error {
 	ct, exist := c.Ctx.Request.Header["Content-Type"]
 	if !exist || len(ct) == 0 {
-		return c.BindJson(obj)
+		return c.BindJSON(obj)
 	}
 	i, l := 0, len(ct[0])
 	for i < l && ct[0][i] != ';' {
@@ -255,7 +255,7 @@ func (c *Controller) Bind(obj interface{}) error {
 	}
 	switch ct[0][0:i] {
 	case "application/json":
-		return c.BindJson(obj)
+		return c.BindJSON(obj)
 	case "application/xml", "text/xml":
 		return c.BindXML(obj)
 	case "application/x-www-form-urlencoded":
@@ -277,7 +277,7 @@ func (c *Controller) BindForm(obj interface{}) error {
 	return c.ParseForm(obj)
 }
 
-func (c *Controller) BindJson(obj interface{}) error {
+func (c *Controller) BindJSON(obj interface{}) error {
 	return json.Unmarshal(c.Ctx.Input.RequestBody, obj)
 }
 
@@ -439,12 +439,12 @@ func (c *Controller) URLFor(endpoint string, values ...interface{}) string {
 	return URLFor(endpoint, values...)
 }
 
-func (c *Controller) JsonResp(data interface{}) error {
-	c.Data["json"]=data
+func (c *Controller) JSONResp(data interface{}) error {
+	c.Data["json"] = data
 	return c.ServeJSON()
 }
 
-func (c *Controller) XmlResp(data interface{}) error {
+func (c *Controller) XMLResp(data interface{}) error {
 	c.Data["xml"] = data
 	return c.ServeXML()
 }

--- a/server/web/controller.go
+++ b/server/web/controller.go
@@ -439,6 +439,21 @@ func (c *Controller) URLFor(endpoint string, values ...interface{}) string {
 	return URLFor(endpoint, values...)
 }
 
+func (c *Controller) JsonResp(data interface{}) error {
+	c.Data["json"]=data
+	return c.ServeJSON()
+}
+
+func (c *Controller) XmlResp(data interface{}) error {
+	c.Data["xml"] = data
+	return c.ServeXML()
+}
+
+func (c *Controller) YamlResp(data interface{}) error {
+	c.Data["yaml"] = data
+	return c.ServeYAML()
+}
+
 // Resp sends response based on the Accept Header
 // By default response will be in JSON
 func (c *Controller) Resp(data interface{}) error {

--- a/server/web/filter.go
+++ b/server/web/filter.go
@@ -26,7 +26,9 @@ import (
 type FilterChain func(next FilterFunc) FilterFunc
 
 // FilterFunc defines a filter function which is invoked before the controller handler is executed.
-type FilterFunc func(ctx *context.Context)
+// It's a alias of HandleFunc
+// In fact, the HandleFunc is the last Filter. This is the truth
+type FilterFunc=HandleFunc
 
 // FilterRouter defines a filter operation which is invoked before the controller handler is executed.
 // It can match the URL against a pattern, and execute a filter function

--- a/server/web/filter.go
+++ b/server/web/filter.go
@@ -28,7 +28,7 @@ type FilterChain func(next FilterFunc) FilterFunc
 // FilterFunc defines a filter function which is invoked before the controller handler is executed.
 // It's a alias of HandleFunc
 // In fact, the HandleFunc is the last Filter. This is the truth
-type FilterFunc=HandleFunc
+type FilterFunc = HandleFunc
 
 // FilterRouter defines a filter operation which is invoked before the controller handler is executed.
 // It can match the URL against a pattern, and execute a filter function

--- a/server/web/namespace.go
+++ b/server/web/namespace.go
@@ -119,56 +119,56 @@ func (n *Namespace) AutoPrefix(prefix string, c ControllerInterface) *Namespace 
 
 // Get same as beego.Get
 // refer: https://godoc.org/github.com/beego/beego/v2#Get
-func (n *Namespace) Get(rootpath string, f FilterFunc) *Namespace {
+func (n *Namespace) Get(rootpath string, f HandleFunc) *Namespace {
 	n.handlers.Get(rootpath, f)
 	return n
 }
 
 // Post same as beego.Post
 // refer: https://godoc.org/github.com/beego/beego/v2#Post
-func (n *Namespace) Post(rootpath string, f FilterFunc) *Namespace {
+func (n *Namespace) Post(rootpath string, f HandleFunc) *Namespace {
 	n.handlers.Post(rootpath, f)
 	return n
 }
 
 // Delete same as beego.Delete
 // refer: https://godoc.org/github.com/beego/beego/v2#Delete
-func (n *Namespace) Delete(rootpath string, f FilterFunc) *Namespace {
+func (n *Namespace) Delete(rootpath string, f HandleFunc) *Namespace {
 	n.handlers.Delete(rootpath, f)
 	return n
 }
 
 // Put same as beego.Put
 // refer: https://godoc.org/github.com/beego/beego/v2#Put
-func (n *Namespace) Put(rootpath string, f FilterFunc) *Namespace {
+func (n *Namespace) Put(rootpath string, f HandleFunc) *Namespace {
 	n.handlers.Put(rootpath, f)
 	return n
 }
 
 // Head same as beego.Head
 // refer: https://godoc.org/github.com/beego/beego/v2#Head
-func (n *Namespace) Head(rootpath string, f FilterFunc) *Namespace {
+func (n *Namespace) Head(rootpath string, f HandleFunc) *Namespace {
 	n.handlers.Head(rootpath, f)
 	return n
 }
 
 // Options same as beego.Options
 // refer: https://godoc.org/github.com/beego/beego/v2#Options
-func (n *Namespace) Options(rootpath string, f FilterFunc) *Namespace {
+func (n *Namespace) Options(rootpath string, f HandleFunc) *Namespace {
 	n.handlers.Options(rootpath, f)
 	return n
 }
 
 // Patch same as beego.Patch
 // refer: https://godoc.org/github.com/beego/beego/v2#Patch
-func (n *Namespace) Patch(rootpath string, f FilterFunc) *Namespace {
+func (n *Namespace) Patch(rootpath string, f HandleFunc) *Namespace {
 	n.handlers.Patch(rootpath, f)
 	return n
 }
 
 // Any same as beego.Any
 // refer: https://godoc.org/github.com/beego/beego/v2#Any
-func (n *Namespace) Any(rootpath string, f FilterFunc) *Namespace {
+func (n *Namespace) Any(rootpath string, f HandleFunc) *Namespace {
 	n.handlers.Any(rootpath, f)
 	return n
 }
@@ -187,51 +187,51 @@ func (n *Namespace) Include(cList ...ControllerInterface) *Namespace {
 	return n
 }
 
-// RouterGet same as beego.RouterGet
-func (n *Namespace) RouterGet(rootpath string, f interface{}) *Namespace {
-	n.handlers.RouterGet(rootpath, f)
+// CtrlGet same as beego.CtrlGet
+func (n *Namespace) CtrlGet(rootpath string, f interface{}) *Namespace {
+	n.handlers.CtrlGet(rootpath, f)
 	return n
 }
 
-// RouterPost same as beego.RouterPost
-func (n *Namespace) RouterPost(rootpath string, f interface{}) *Namespace {
-	n.handlers.RouterPost(rootpath, f)
+// CtrlPost same as beego.CtrlPost
+func (n *Namespace) CtrlPost(rootpath string, f interface{}) *Namespace {
+	n.handlers.CtrlPost(rootpath, f)
 	return n
 }
 
-// RouterDelete same as beego.RouterDelete
-func (n *Namespace) RouterDelete(rootpath string, f interface{}) *Namespace {
-	n.handlers.RouterDelete(rootpath, f)
+// CtrlDelete same as beego.CtrlDelete
+func (n *Namespace) CtrlDelete(rootpath string, f interface{}) *Namespace {
+	n.handlers.CtrlDelete(rootpath, f)
 	return n
 }
 
-// RouterPut same as beego.RouterPut
-func (n *Namespace) RouterPut(rootpath string, f interface{}) *Namespace {
-	n.handlers.RouterPut(rootpath, f)
+// CtrlPut same as beego.CtrlPut
+func (n *Namespace) CtrlPut(rootpath string, f interface{}) *Namespace {
+	n.handlers.CtrlPut(rootpath, f)
 	return n
 }
 
-// RouterHead same as beego.RouterHead
-func (n *Namespace) RouterHead(rootpath string, f interface{}) *Namespace {
-	n.handlers.RouterHead(rootpath, f)
+// CtrlHead same as beego.CtrlHead
+func (n *Namespace) CtrlHead(rootpath string, f interface{}) *Namespace {
+	n.handlers.CtrlHead(rootpath, f)
 	return n
 }
 
-// RouterOptions same as beego.RouterOptions
-func (n *Namespace) RouterOptions(rootpath string, f interface{}) *Namespace {
-	n.handlers.RouterOptions(rootpath, f)
+// CtrlOptions same as beego.CtrlOptions
+func (n *Namespace) CtrlOptions(rootpath string, f interface{}) *Namespace {
+	n.handlers.CtrlOptions(rootpath, f)
 	return n
 }
 
-// RouterPatch same as beego.RouterPatch
-func (n *Namespace) RouterPatch(rootpath string, f interface{}) *Namespace {
-	n.handlers.RouterPatch(rootpath, f)
+// CtrlPatch same as beego.CtrlPatch
+func (n *Namespace) CtrlPatch(rootpath string, f interface{}) *Namespace {
+	n.handlers.CtrlPatch(rootpath, f)
 	return n
 }
 
-// Any same as beego.RouterAny
-func (n *Namespace) RouterAny(rootpath string, f interface{}) *Namespace {
-	n.handlers.RouterAny(rootpath, f)
+// Any same as beego.CtrlAny
+func (n *Namespace) CtrlAny(rootpath string, f interface{}) *Namespace {
+	n.handlers.CtrlAny(rootpath, f)
 	return n
 }
 
@@ -359,114 +359,114 @@ func NSRouter(rootpath string, c ControllerInterface, mappingMethods ...string) 
 }
 
 // NSGet call Namespace Get
-func NSGet(rootpath string, f FilterFunc) LinkNamespace {
+func NSGet(rootpath string, f HandleFunc) LinkNamespace {
 	return func(ns *Namespace) {
 		ns.Get(rootpath, f)
 	}
 }
 
 // NSPost call Namespace Post
-func NSPost(rootpath string, f FilterFunc) LinkNamespace {
+func NSPost(rootpath string, f HandleFunc) LinkNamespace {
 	return func(ns *Namespace) {
 		ns.Post(rootpath, f)
 	}
 }
 
 // NSHead call Namespace Head
-func NSHead(rootpath string, f FilterFunc) LinkNamespace {
+func NSHead(rootpath string, f HandleFunc) LinkNamespace {
 	return func(ns *Namespace) {
 		ns.Head(rootpath, f)
 	}
 }
 
 // NSPut call Namespace Put
-func NSPut(rootpath string, f FilterFunc) LinkNamespace {
+func NSPut(rootpath string, f HandleFunc) LinkNamespace {
 	return func(ns *Namespace) {
 		ns.Put(rootpath, f)
 	}
 }
 
 // NSDelete call Namespace Delete
-func NSDelete(rootpath string, f FilterFunc) LinkNamespace {
+func NSDelete(rootpath string, f HandleFunc) LinkNamespace {
 	return func(ns *Namespace) {
 		ns.Delete(rootpath, f)
 	}
 }
 
 // NSAny call Namespace Any
-func NSAny(rootpath string, f FilterFunc) LinkNamespace {
+func NSAny(rootpath string, f HandleFunc) LinkNamespace {
 	return func(ns *Namespace) {
 		ns.Any(rootpath, f)
 	}
 }
 
 // NSOptions call Namespace Options
-func NSOptions(rootpath string, f FilterFunc) LinkNamespace {
+func NSOptions(rootpath string, f HandleFunc) LinkNamespace {
 	return func(ns *Namespace) {
 		ns.Options(rootpath, f)
 	}
 }
 
 // NSPatch call Namespace Patch
-func NSPatch(rootpath string, f FilterFunc) LinkNamespace {
+func NSPatch(rootpath string, f HandleFunc) LinkNamespace {
 	return func(ns *Namespace) {
 		ns.Patch(rootpath, f)
 	}
 }
 
-// NSRouterGet call Namespace RouterGet
-func NSRouterGet(rootpath string, f interface{}) LinkNamespace {
+// NSCtrlGet call Namespace CtrlGet
+func NSCtrlGet(rootpath string, f interface{}) LinkNamespace {
 	return func(ns *Namespace) {
-		ns.RouterGet(rootpath, f)
+		ns.CtrlGet(rootpath, f)
 	}
 }
 
-// NSRouterPost call Namespace RouterPost
-func NSRouterPost(rootpath string, f interface{}) LinkNamespace {
+// NSCtrlPost call Namespace CtrlPost
+func NSCtrlPost(rootpath string, f interface{}) LinkNamespace {
 	return func(ns *Namespace) {
-		ns.RouterPost(rootpath, f)
+		ns.CtrlPost(rootpath, f)
 	}
 }
 
-// NSRouterHead call Namespace RouterHead
-func NSRouterHead(rootpath string, f interface{}) LinkNamespace {
+// NSCtrlHead call Namespace CtrlHead
+func NSCtrlHead(rootpath string, f interface{}) LinkNamespace {
 	return func(ns *Namespace) {
-		ns.RouterHead(rootpath, f)
+		ns.CtrlHead(rootpath, f)
 	}
 }
 
-// NSRouterPut call Namespace RouterPut
-func NSRouterPut(rootpath string, f interface{}) LinkNamespace {
+// NSCtrlPut call Namespace CtrlPut
+func NSCtrlPut(rootpath string, f interface{}) LinkNamespace {
 	return func(ns *Namespace) {
-		ns.RouterPut(rootpath, f)
+		ns.CtrlPut(rootpath, f)
 	}
 }
 
-// NSRouterDelete call Namespace RouterDelete
-func NSRouterDelete(rootpath string, f interface{}) LinkNamespace {
+// NSCtrlDelete call Namespace CtrlDelete
+func NSCtrlDelete(rootpath string, f interface{}) LinkNamespace {
 	return func(ns *Namespace) {
-		ns.RouterDelete(rootpath, f)
+		ns.CtrlDelete(rootpath, f)
 	}
 }
 
-// NSRouterAny call Namespace RouterAny
-func NSRouterAny(rootpath string, f interface{}) LinkNamespace {
+// NSCtrlAny call Namespace CtrlAny
+func NSCtrlAny(rootpath string, f interface{}) LinkNamespace {
 	return func(ns *Namespace) {
-		ns.RouterAny(rootpath, f)
+		ns.CtrlAny(rootpath, f)
 	}
 }
 
-// NSRouterOptions call Namespace RouterOptions
-func NSRouterOptions(rootpath string, f interface{}) LinkNamespace {
+// NSCtrlOptions call Namespace CtrlOptions
+func NSCtrlOptions(rootpath string, f interface{}) LinkNamespace {
 	return func(ns *Namespace) {
-		ns.RouterOptions(rootpath, f)
+		ns.CtrlOptions(rootpath, f)
 	}
 }
 
-// NSRouterPatch call Namespace RouterPatch
-func NSRouterPatch(rootpath string, f interface{}) LinkNamespace {
+// NSCtrlPatch call Namespace CtrlPatch
+func NSCtrlPatch(rootpath string, f interface{}) LinkNamespace {
 	return func(ns *Namespace) {
-		ns.RouterPatch(rootpath, f)
+		ns.CtrlPatch(rootpath, f)
 	}
 }
 

--- a/server/web/namespace_test.go
+++ b/server/web/namespace_test.go
@@ -202,100 +202,100 @@ func TestNamespaceInside(t *testing.T) {
 	}
 }
 
-func TestNamespaceRouterGet(t *testing.T) {
+func TestNamespaceCtrlGet(t *testing.T) {
 	r, _ := http.NewRequest(http.MethodGet, nsNamespacePath, nil)
 	w := httptest.NewRecorder()
 
 	ns := NewNamespace(nsNamespace)
-	ns.RouterGet(nsPath, ExampleController.Ping)
+	ns.CtrlGet(nsPath, ExampleController.Ping)
 	AddNamespace(ns)
 	BeeApp.Handlers.ServeHTTP(w, r)
 	if w.Body.String() != exampleBody {
-		t.Errorf("TestNamespaceRouterGet can't run, get the response is " + w.Body.String())
+		t.Errorf("TestNamespaceCtrlGet can't run, get the response is " + w.Body.String())
 	}
 }
 
-func TestNamespaceRouterPost(t *testing.T) {
+func TestNamespaceCtrlPost(t *testing.T) {
 	r, _ := http.NewRequest(http.MethodPost, nsNamespacePath, nil)
 	w := httptest.NewRecorder()
 
 	ns := NewNamespace(nsNamespace)
-	ns.RouterPost(nsPath, ExampleController.Ping)
+	ns.CtrlPost(nsPath, ExampleController.Ping)
 	AddNamespace(ns)
 	BeeApp.Handlers.ServeHTTP(w, r)
 	if w.Body.String() != exampleBody {
-		t.Errorf("TestNamespaceRouterPost can't run, get the response is " + w.Body.String())
+		t.Errorf("TestNamespaceCtrlPost can't run, get the response is " + w.Body.String())
 	}
 }
 
-func TestNamespaceRouterDelete(t *testing.T) {
+func TestNamespaceCtrlDelete(t *testing.T) {
 	r, _ := http.NewRequest(http.MethodDelete, nsNamespacePath, nil)
 	w := httptest.NewRecorder()
 
 	ns := NewNamespace(nsNamespace)
-	ns.RouterDelete(nsPath, ExampleController.Ping)
+	ns.CtrlDelete(nsPath, ExampleController.Ping)
 	AddNamespace(ns)
 	BeeApp.Handlers.ServeHTTP(w, r)
 	if w.Body.String() != exampleBody {
-		t.Errorf("TestNamespaceRouterDelete can't run, get the response is " + w.Body.String())
+		t.Errorf("TestNamespaceCtrlDelete can't run, get the response is " + w.Body.String())
 	}
 }
 
-func TestNamespaceRouterPut(t *testing.T) {
+func TestNamespaceCtrlPut(t *testing.T) {
 	r, _ := http.NewRequest(http.MethodPut, nsNamespacePath, nil)
 	w := httptest.NewRecorder()
 
 	ns := NewNamespace(nsNamespace)
-	ns.RouterPut(nsPath, ExampleController.Ping)
+	ns.CtrlPut(nsPath, ExampleController.Ping)
 	AddNamespace(ns)
 	BeeApp.Handlers.ServeHTTP(w, r)
 	if w.Body.String() != exampleBody {
-		t.Errorf("TestNamespaceRouterPut can't run, get the response is " + w.Body.String())
+		t.Errorf("TestNamespaceCtrlPut can't run, get the response is " + w.Body.String())
 	}
 }
 
-func TestNamespaceRouterHead(t *testing.T) {
+func TestNamespaceCtrlHead(t *testing.T) {
 	r, _ := http.NewRequest(http.MethodHead, nsNamespacePath, nil)
 	w := httptest.NewRecorder()
 
 	ns := NewNamespace(nsNamespace)
-	ns.RouterHead(nsPath, ExampleController.Ping)
+	ns.CtrlHead(nsPath, ExampleController.Ping)
 	AddNamespace(ns)
 	BeeApp.Handlers.ServeHTTP(w, r)
 	if w.Body.String() != exampleBody {
-		t.Errorf("TestNamespaceRouterHead can't run, get the response is " + w.Body.String())
+		t.Errorf("TestNamespaceCtrlHead can't run, get the response is " + w.Body.String())
 	}
 }
 
-func TestNamespaceRouterOptions(t *testing.T) {
+func TestNamespaceCtrlOptions(t *testing.T) {
 	r, _ := http.NewRequest(http.MethodOptions, nsNamespacePath, nil)
 	w := httptest.NewRecorder()
 
 	ns := NewNamespace(nsNamespace)
-	ns.RouterOptions(nsPath, ExampleController.Ping)
+	ns.CtrlOptions(nsPath, ExampleController.Ping)
 	AddNamespace(ns)
 	BeeApp.Handlers.ServeHTTP(w, r)
 	if w.Body.String() != exampleBody {
-		t.Errorf("TestNamespaceRouterOptions can't run, get the response is " + w.Body.String())
+		t.Errorf("TestNamespaceCtrlOptions can't run, get the response is " + w.Body.String())
 	}
 }
 
-func TestNamespaceRouterPatch(t *testing.T) {
+func TestNamespaceCtrlPatch(t *testing.T) {
 	r, _ := http.NewRequest(http.MethodPatch, nsNamespacePath, nil)
 	w := httptest.NewRecorder()
 
 	ns := NewNamespace(nsNamespace)
-	ns.RouterPatch(nsPath, ExampleController.Ping)
+	ns.CtrlPatch(nsPath, ExampleController.Ping)
 	AddNamespace(ns)
 	BeeApp.Handlers.ServeHTTP(w, r)
 	if w.Body.String() != exampleBody {
-		t.Errorf("TestNamespaceRouterPatch can't run, get the response is " + w.Body.String())
+		t.Errorf("TestNamespaceCtrlPatch can't run, get the response is " + w.Body.String())
 	}
 }
 
-func TestNamespaceRouterAny(t *testing.T) {
+func TestNamespaceCtrlAny(t *testing.T) {
 	ns := NewNamespace(nsNamespace)
-	ns.RouterAny(nsPath, ExampleController.Ping)
+	ns.CtrlAny(nsPath, ExampleController.Ping)
 	AddNamespace(ns)
 
 	for method := range HTTPMETHOD {
@@ -303,105 +303,105 @@ func TestNamespaceRouterAny(t *testing.T) {
 		r, _ := http.NewRequest(method, nsNamespacePath, nil)
 		BeeApp.Handlers.ServeHTTP(w, r)
 		if w.Body.String() != exampleBody {
-			t.Errorf("TestNamespaceRouterAny can't run, get the response is " + w.Body.String())
+			t.Errorf("TestNamespaceCtrlAny can't run, get the response is " + w.Body.String())
 		}
 	}
 }
 
-func TestNamespaceNSRouterGet(t *testing.T) {
+func TestNamespaceNSCtrlGet(t *testing.T) {
 	r, _ := http.NewRequest(http.MethodGet, nsNamespacePath, nil)
 	w := httptest.NewRecorder()
 
 	ns := NewNamespace(nsNamespace)
-	NSRouterGet(nsPath, ExampleController.Ping)(ns)
+	NSCtrlGet(nsPath, ExampleController.Ping)(ns)
 	AddNamespace(ns)
 	BeeApp.Handlers.ServeHTTP(w, r)
 	if w.Body.String() != exampleBody {
-		t.Errorf("TestNamespaceNSRouterGet can't run, get the response is " + w.Body.String())
+		t.Errorf("TestNamespaceNSCtrlGet can't run, get the response is " + w.Body.String())
 	}
 }
 
-func TestNamespaceNSRouterPost(t *testing.T) {
+func TestNamespaceNSCtrlPost(t *testing.T) {
 	r, _ := http.NewRequest(http.MethodPost, nsNamespacePath, nil)
 	w := httptest.NewRecorder()
 
 	ns := NewNamespace("/router")
-	NSRouterPost(nsPath, ExampleController.Ping)(ns)
+	NSCtrlPost(nsPath, ExampleController.Ping)(ns)
 	AddNamespace(ns)
 	BeeApp.Handlers.ServeHTTP(w, r)
 	if w.Body.String() != exampleBody {
-		t.Errorf("TestNamespaceNSRouterPost can't run, get the response is " + w.Body.String())
+		t.Errorf("TestNamespaceNSCtrlPost can't run, get the response is " + w.Body.String())
 	}
 }
 
-func TestNamespaceNSRouterDelete(t *testing.T) {
+func TestNamespaceNSCtrlDelete(t *testing.T) {
 	r, _ := http.NewRequest(http.MethodDelete, nsNamespacePath, nil)
 	w := httptest.NewRecorder()
 
 	ns := NewNamespace(nsNamespace)
-	NSRouterDelete(nsPath, ExampleController.Ping)(ns)
+	NSCtrlDelete(nsPath, ExampleController.Ping)(ns)
 	AddNamespace(ns)
 	BeeApp.Handlers.ServeHTTP(w, r)
 	if w.Body.String() != exampleBody {
-		t.Errorf("TestNamespaceNSRouterDelete can't run, get the response is " + w.Body.String())
+		t.Errorf("TestNamespaceNSCtrlDelete can't run, get the response is " + w.Body.String())
 	}
 }
 
-func TestNamespaceNSRouterPut(t *testing.T) {
+func TestNamespaceNSCtrlPut(t *testing.T) {
 	r, _ := http.NewRequest(http.MethodPut, nsNamespacePath, nil)
 	w := httptest.NewRecorder()
 
 	ns := NewNamespace(nsNamespace)
-	NSRouterPut(nsPath, ExampleController.Ping)(ns)
+	NSCtrlPut(nsPath, ExampleController.Ping)(ns)
 	AddNamespace(ns)
 	BeeApp.Handlers.ServeHTTP(w, r)
 	if w.Body.String() != exampleBody {
-		t.Errorf("TestNamespaceNSRouterPut can't run, get the response is " + w.Body.String())
+		t.Errorf("TestNamespaceNSCtrlPut can't run, get the response is " + w.Body.String())
 	}
 }
 
-func TestNamespaceNSRouterHead(t *testing.T) {
+func TestNamespaceNSCtrlHead(t *testing.T) {
 	r, _ := http.NewRequest(http.MethodHead, nsNamespacePath, nil)
 	w := httptest.NewRecorder()
 
 	ns := NewNamespace(nsNamespace)
-	NSRouterHead(nsPath, ExampleController.Ping)(ns)
+	NSCtrlHead(nsPath, ExampleController.Ping)(ns)
 	AddNamespace(ns)
 	BeeApp.Handlers.ServeHTTP(w, r)
 	if w.Body.String() != exampleBody {
-		t.Errorf("TestNamespaceNSRouterHead can't run, get the response is " + w.Body.String())
+		t.Errorf("TestNamespaceNSCtrlHead can't run, get the response is " + w.Body.String())
 	}
 }
 
-func TestNamespaceNSRouterOptions(t *testing.T) {
+func TestNamespaceNSCtrlOptions(t *testing.T) {
 	r, _ := http.NewRequest(http.MethodOptions, nsNamespacePath, nil)
 	w := httptest.NewRecorder()
 
 	ns := NewNamespace(nsNamespace)
-	NSRouterOptions(nsPath, ExampleController.Ping)(ns)
+	NSCtrlOptions(nsPath, ExampleController.Ping)(ns)
 	AddNamespace(ns)
 	BeeApp.Handlers.ServeHTTP(w, r)
 	if w.Body.String() != exampleBody {
-		t.Errorf("TestNamespaceNSRouterOptions can't run, get the response is " + w.Body.String())
+		t.Errorf("TestNamespaceNSCtrlOptions can't run, get the response is " + w.Body.String())
 	}
 }
 
-func TestNamespaceNSRouterPatch(t *testing.T) {
+func TestNamespaceNSCtrlPatch(t *testing.T) {
 	r, _ := http.NewRequest(http.MethodPatch, nsNamespacePath, nil)
 	w := httptest.NewRecorder()
 
 	ns := NewNamespace(nsNamespace)
-	NSRouterPatch("/user", ExampleController.Ping)(ns)
+	NSCtrlPatch("/user", ExampleController.Ping)(ns)
 	AddNamespace(ns)
 	BeeApp.Handlers.ServeHTTP(w, r)
 	if w.Body.String() != exampleBody {
-		t.Errorf("TestNamespaceNSRouterPatch can't run, get the response is " + w.Body.String())
+		t.Errorf("TestNamespaceNSCtrlPatch can't run, get the response is " + w.Body.String())
 	}
 }
 
-func TestNamespaceNSRouterAny(t *testing.T) {
+func TestNamespaceNSCtrlAny(t *testing.T) {
 	ns := NewNamespace(nsNamespace)
-	NSRouterAny(nsPath, ExampleController.Ping)(ns)
+	NSCtrlAny(nsPath, ExampleController.Ping)(ns)
 	AddNamespace(ns)
 
 	for method := range HTTPMETHOD {
@@ -409,7 +409,7 @@ func TestNamespaceNSRouterAny(t *testing.T) {
 		r, _ := http.NewRequest(method, nsNamespacePath, nil)
 		BeeApp.Handlers.ServeHTTP(w, r)
 		if w.Body.String() != exampleBody {
-			t.Errorf("TestNamespaceNSRouterAny can't run, get the response is " + w.Body.String())
+			t.Errorf("TestNamespaceNSCtrlAny can't run, get the response is " + w.Body.String())
 		}
 	}
 }

--- a/server/web/router.go
+++ b/server/web/router.go
@@ -119,7 +119,7 @@ type ControllerInfo struct {
 	controllerType reflect.Type
 	methods        map[string]string
 	handler        http.Handler
-	runFunction    FilterFunc
+	runFunction    HandleFunc
 	routerType     int
 	initialize     func() ControllerInterface
 	methodParams   []*param.MethodParam
@@ -354,7 +354,7 @@ func (p *ControllerRegister) GiveBackContext(ctx *beecontext.Context) {
 	p.pool.Put(ctx)
 }
 
-// RouterGet add get method
+// CtrlGet add get method
 // usage:
 //    type MyController struct {
 //	     web.Controller
@@ -363,12 +363,13 @@ func (p *ControllerRegister) GiveBackContext(ctx *beecontext.Context) {
 //	     m.Ctx.Output.Body([]byte("hello world"))
 //    }
 //
-//    RouterGet("/api/:id", MyController.Ping)
-func (p *ControllerRegister) RouterGet(pattern string, f interface{}) {
+//    CtrlGet("/api/:id", MyController.Ping)
+// If the receiver of function Ping is pointer, you should use CtrlGet("/api/:id", (*MyController).Ping)
+func (p *ControllerRegister) CtrlGet(pattern string, f interface{}) {
 	p.AddRouterMethod(http.MethodGet, pattern, f)
 }
 
-// RouterPost add post method
+// CtrlPost add post method
 // usage:
 //    type MyController struct {
 //	     web.Controller
@@ -377,12 +378,13 @@ func (p *ControllerRegister) RouterGet(pattern string, f interface{}) {
 //	     m.Ctx.Output.Body([]byte("hello world"))
 //    }
 //
-//    RouterPost("/api/:id", MyController.Ping)
-func (p *ControllerRegister) RouterPost(pattern string, f interface{}) {
+//    CtrlPost("/api/:id", MyController.Ping)
+// If the receiver of function Ping is pointer, you should use CtrlPost("/api/:id", (*MyController).Ping)
+func (p *ControllerRegister) CtrlPost(pattern string, f interface{}) {
 	p.AddRouterMethod(http.MethodPost, pattern, f)
 }
 
-// RouterHead add head method
+// CtrlHead add head method
 // usage:
 //    type MyController struct {
 //	     web.Controller
@@ -391,12 +393,13 @@ func (p *ControllerRegister) RouterPost(pattern string, f interface{}) {
 //	     m.Ctx.Output.Body([]byte("hello world"))
 //    }
 //
-//    RouterHead("/api/:id", MyController.Ping)
-func (p *ControllerRegister) RouterHead(pattern string, f interface{}) {
+//    CtrlHead("/api/:id", MyController.Ping)
+// If the receiver of function Ping is pointer, you should use CtrlHead("/api/:id", (*MyController).Ping)
+func (p *ControllerRegister) CtrlHead(pattern string, f interface{}) {
 	p.AddRouterMethod(http.MethodHead, pattern, f)
 }
 
-// RouterPut add put method
+// CtrlPut add put method
 // usage:
 //    type MyController struct {
 //	     web.Controller
@@ -405,12 +408,13 @@ func (p *ControllerRegister) RouterHead(pattern string, f interface{}) {
 //	     m.Ctx.Output.Body([]byte("hello world"))
 //    }
 //
-//    RouterPut("/api/:id", MyController.Ping)
-func (p *ControllerRegister) RouterPut(pattern string, f interface{}) {
+//    CtrlPut("/api/:id", MyController.Ping)
+
+func (p *ControllerRegister) CtrlPut(pattern string, f interface{}) {
 	p.AddRouterMethod(http.MethodPut, pattern, f)
 }
 
-// RouterPatch add patch method
+// CtrlPatch add patch method
 // usage:
 //    type MyController struct {
 //	     web.Controller
@@ -419,12 +423,12 @@ func (p *ControllerRegister) RouterPut(pattern string, f interface{}) {
 //	     m.Ctx.Output.Body([]byte("hello world"))
 //    }
 //
-//    RouterPatch("/api/:id", MyController.Ping)
-func (p *ControllerRegister) RouterPatch(pattern string, f interface{}) {
+//    CtrlPatch("/api/:id", MyController.Ping)
+func (p *ControllerRegister) CtrlPatch(pattern string, f interface{}) {
 	p.AddRouterMethod(http.MethodPatch, pattern, f)
 }
 
-// RouterDelete add delete method
+// CtrlDelete add delete method
 // usage:
 //    type MyController struct {
 //	     web.Controller
@@ -433,12 +437,12 @@ func (p *ControllerRegister) RouterPatch(pattern string, f interface{}) {
 //	     m.Ctx.Output.Body([]byte("hello world"))
 //    }
 //
-//    RouterDelete("/api/:id", MyController.Ping)
-func (p *ControllerRegister) RouterDelete(pattern string, f interface{}) {
+//    CtrlDelete("/api/:id", MyController.Ping)
+func (p *ControllerRegister) CtrlDelete(pattern string, f interface{}) {
 	p.AddRouterMethod(http.MethodDelete, pattern, f)
 }
 
-// RouterOptions add options method
+// CtrlOptions add options method
 // usage:
 //    type MyController struct {
 //	     web.Controller
@@ -447,12 +451,12 @@ func (p *ControllerRegister) RouterDelete(pattern string, f interface{}) {
 //	     m.Ctx.Output.Body([]byte("hello world"))
 //    }
 //
-//    RouterOptions("/api/:id", MyController.Ping)
-func (p *ControllerRegister) RouterOptions(pattern string, f interface{}) {
+//    CtrlOptions("/api/:id", MyController.Ping)
+func (p *ControllerRegister) CtrlOptions(pattern string, f interface{}) {
 	p.AddRouterMethod(http.MethodOptions, pattern, f)
 }
 
-// RouterAny add all method
+// CtrlAny add all method
 // usage:
 //    type MyController struct {
 //	     web.Controller
@@ -461,8 +465,8 @@ func (p *ControllerRegister) RouterOptions(pattern string, f interface{}) {
 //	     m.Ctx.Output.Body([]byte("hello world"))
 //    }
 //
-//    RouterAny("/api/:id", MyController.Ping)
-func (p *ControllerRegister) RouterAny(pattern string, f interface{}) {
+//    CtrlAny("/api/:id", MyController.Ping)
+func (p *ControllerRegister) CtrlAny(pattern string, f interface{}) {
 	p.AddRouterMethod("*", pattern, f)
 }
 
@@ -503,7 +507,7 @@ func (p *ControllerRegister) createBeegoRouter(ct reflect.Type, pattern string) 
 }
 
 // createRestfulRouter create restful router with filter function and pattern
-func (p *ControllerRegister) createRestfulRouter(f FilterFunc, pattern string) *ControllerInfo {
+func (p *ControllerRegister) createRestfulRouter(f HandleFunc, pattern string) *ControllerInfo {
 	route := &ControllerInfo{}
 	route.pattern = pattern
 	route.routerType = routerTypeRESTFul
@@ -609,12 +613,15 @@ func getReflectTypeAndMethod(f interface{}) (controllerType reflect.Type, method
 	return
 }
 
+// HandleFunc define how to process the request
+type HandleFunc func(ctx *beecontext.Context)
+
 // Get add get method
 // usage:
 //    Get("/", func(ctx *context.Context){
 //          ctx.Output.Body("hello world")
 //    })
-func (p *ControllerRegister) Get(pattern string, f FilterFunc) {
+func (p *ControllerRegister) Get(pattern string, f HandleFunc) {
 	p.AddMethod("get", pattern, f)
 }
 
@@ -623,7 +630,7 @@ func (p *ControllerRegister) Get(pattern string, f FilterFunc) {
 //    Post("/api", func(ctx *context.Context){
 //          ctx.Output.Body("hello world")
 //    })
-func (p *ControllerRegister) Post(pattern string, f FilterFunc) {
+func (p *ControllerRegister) Post(pattern string, f HandleFunc) {
 	p.AddMethod("post", pattern, f)
 }
 
@@ -632,7 +639,7 @@ func (p *ControllerRegister) Post(pattern string, f FilterFunc) {
 //    Put("/api/:id", func(ctx *context.Context){
 //          ctx.Output.Body("hello world")
 //    })
-func (p *ControllerRegister) Put(pattern string, f FilterFunc) {
+func (p *ControllerRegister) Put(pattern string, f HandleFunc) {
 	p.AddMethod("put", pattern, f)
 }
 
@@ -641,7 +648,7 @@ func (p *ControllerRegister) Put(pattern string, f FilterFunc) {
 //    Delete("/api/:id", func(ctx *context.Context){
 //          ctx.Output.Body("hello world")
 //    })
-func (p *ControllerRegister) Delete(pattern string, f FilterFunc) {
+func (p *ControllerRegister) Delete(pattern string, f HandleFunc) {
 	p.AddMethod("delete", pattern, f)
 }
 
@@ -650,7 +657,7 @@ func (p *ControllerRegister) Delete(pattern string, f FilterFunc) {
 //    Head("/api/:id", func(ctx *context.Context){
 //          ctx.Output.Body("hello world")
 //    })
-func (p *ControllerRegister) Head(pattern string, f FilterFunc) {
+func (p *ControllerRegister) Head(pattern string, f HandleFunc) {
 	p.AddMethod("head", pattern, f)
 }
 
@@ -659,7 +666,7 @@ func (p *ControllerRegister) Head(pattern string, f FilterFunc) {
 //    Patch("/api/:id", func(ctx *context.Context){
 //          ctx.Output.Body("hello world")
 //    })
-func (p *ControllerRegister) Patch(pattern string, f FilterFunc) {
+func (p *ControllerRegister) Patch(pattern string, f HandleFunc) {
 	p.AddMethod("patch", pattern, f)
 }
 
@@ -668,7 +675,7 @@ func (p *ControllerRegister) Patch(pattern string, f FilterFunc) {
 //    Options("/api/:id", func(ctx *context.Context){
 //          ctx.Output.Body("hello world")
 //    })
-func (p *ControllerRegister) Options(pattern string, f FilterFunc) {
+func (p *ControllerRegister) Options(pattern string, f HandleFunc) {
 	p.AddMethod("options", pattern, f)
 }
 
@@ -677,7 +684,7 @@ func (p *ControllerRegister) Options(pattern string, f FilterFunc) {
 //    Any("/api/:id", func(ctx *context.Context){
 //          ctx.Output.Body("hello world")
 //    })
-func (p *ControllerRegister) Any(pattern string, f FilterFunc) {
+func (p *ControllerRegister) Any(pattern string, f HandleFunc) {
 	p.AddMethod("*", pattern, f)
 }
 
@@ -686,7 +693,7 @@ func (p *ControllerRegister) Any(pattern string, f FilterFunc) {
 //    AddMethod("get","/api/:id", func(ctx *context.Context){
 //          ctx.Output.Body("hello world")
 //    })
-func (p *ControllerRegister) AddMethod(method, pattern string, f FilterFunc) {
+func (p *ControllerRegister) AddMethod(method, pattern string, f HandleFunc) {
 	method = p.getUpperMethodString(method)
 
 	route := p.createRestfulRouter(f, pattern)

--- a/server/web/router_test.go
+++ b/server/web/router_test.go
@@ -354,7 +354,7 @@ func TestAutoPrefix(t *testing.T) {
 	}
 }
 
-func TestRouterGet(t *testing.T) {
+func TestCtrlGet(t *testing.T) {
 	r, _ := http.NewRequest("GET", "/user", nil)
 	w := httptest.NewRecorder()
 
@@ -364,11 +364,11 @@ func TestRouterGet(t *testing.T) {
 	})
 	handler.ServeHTTP(w, r)
 	if w.Body.String() != "Get userlist" {
-		t.Errorf("TestRouterGet can't run")
+		t.Errorf("TestCtrlGet can't run")
 	}
 }
 
-func TestRouterPost(t *testing.T) {
+func TestCtrlPost(t *testing.T) {
 	r, _ := http.NewRequest("POST", "/user/123", nil)
 	w := httptest.NewRecorder()
 
@@ -378,7 +378,7 @@ func TestRouterPost(t *testing.T) {
 	})
 	handler.ServeHTTP(w, r)
 	if w.Body.String() != "123" {
-		t.Errorf("TestRouterPost can't run")
+		t.Errorf("TestCtrlPost can't run")
 	}
 }
 
@@ -836,174 +836,174 @@ func TestRouterSessionSet(t *testing.T) {
 	}
 }
 
-func TestRouterRouterGet(t *testing.T) {
+func TestRouterCtrlGet(t *testing.T) {
 	r, _ := http.NewRequest(http.MethodGet, "/user", nil)
 	w := httptest.NewRecorder()
 
 	handler := NewControllerRegister()
-	handler.RouterGet("/user", ExampleController.Ping)
+	handler.CtrlGet("/user", ExampleController.Ping)
 	handler.ServeHTTP(w, r)
 	if w.Body.String() != exampleBody {
-		t.Errorf("TestRouterRouterGet can't run")
+		t.Errorf("TestRouterCtrlGet can't run")
 	}
 }
 
-func TestRouterRouterPost(t *testing.T) {
+func TestRouterCtrlPost(t *testing.T) {
 	r, _ := http.NewRequest(http.MethodPost, "/user", nil)
 	w := httptest.NewRecorder()
 
 	handler := NewControllerRegister()
-	handler.RouterPost("/user", ExampleController.Ping)
+	handler.CtrlPost("/user", ExampleController.Ping)
 	handler.ServeHTTP(w, r)
 	if w.Body.String() != exampleBody {
-		t.Errorf("TestRouterRouterPost can't run")
+		t.Errorf("TestRouterCtrlPost can't run")
 	}
 }
 
-func TestRouterRouterHead(t *testing.T) {
+func TestRouterCtrlHead(t *testing.T) {
 	r, _ := http.NewRequest(http.MethodHead, "/user", nil)
 	w := httptest.NewRecorder()
 
 	handler := NewControllerRegister()
-	handler.RouterHead("/user", ExampleController.Ping)
+	handler.CtrlHead("/user", ExampleController.Ping)
 	handler.ServeHTTP(w, r)
 	if w.Body.String() != exampleBody {
-		t.Errorf("TestRouterRouterHead can't run")
+		t.Errorf("TestRouterCtrlHead can't run")
 	}
 }
 
-func TestRouterRouterPut(t *testing.T) {
+func TestRouterCtrlPut(t *testing.T) {
 	r, _ := http.NewRequest(http.MethodPut, "/user", nil)
 	w := httptest.NewRecorder()
 
 	handler := NewControllerRegister()
-	handler.RouterPut("/user", ExampleController.Ping)
+	handler.CtrlPut("/user", ExampleController.Ping)
 	handler.ServeHTTP(w, r)
 	if w.Body.String() != exampleBody {
-		t.Errorf("TestRouterRouterPut can't run")
+		t.Errorf("TestRouterCtrlPut can't run")
 	}
 }
 
-func TestRouterRouterPatch(t *testing.T) {
+func TestRouterCtrlPatch(t *testing.T) {
 	r, _ := http.NewRequest(http.MethodPatch, "/user", nil)
 	w := httptest.NewRecorder()
 
 	handler := NewControllerRegister()
-	handler.RouterPatch("/user", ExampleController.Ping)
+	handler.CtrlPatch("/user", ExampleController.Ping)
 	handler.ServeHTTP(w, r)
 	if w.Body.String() != exampleBody {
-		t.Errorf("TestRouterRouterPatch can't run")
+		t.Errorf("TestRouterCtrlPatch can't run")
 	}
 }
 
-func TestRouterRouterDelete(t *testing.T) {
+func TestRouterCtrlDelete(t *testing.T) {
 	r, _ := http.NewRequest(http.MethodDelete, "/user", nil)
 	w := httptest.NewRecorder()
 
 	handler := NewControllerRegister()
-	handler.RouterDelete("/user", ExampleController.Ping)
+	handler.CtrlDelete("/user", ExampleController.Ping)
 	handler.ServeHTTP(w, r)
 	if w.Body.String() != exampleBody {
-		t.Errorf("TestRouterRouterDelete can't run")
+		t.Errorf("TestRouterCtrlDelete can't run")
 	}
 }
 
-func TestRouterRouterAny(t *testing.T) {
+func TestRouterCtrlAny(t *testing.T) {
 	handler := NewControllerRegister()
-	handler.RouterAny("/user", ExampleController.Ping)
+	handler.CtrlAny("/user", ExampleController.Ping)
 
 	for method := range HTTPMETHOD {
 		w := httptest.NewRecorder()
 		r, _ := http.NewRequest(method, "/user", nil)
 		handler.ServeHTTP(w, r)
 		if w.Body.String() != exampleBody {
-			t.Errorf("TestRouterRouterAny can't run, get the response is " + w.Body.String())
+			t.Errorf("TestRouterCtrlAny can't run, get the response is " + w.Body.String())
 		}
 	}
 }
 
-func TestRouterRouterGetPointerMethod(t *testing.T) {
+func TestRouterCtrlGetPointerMethod(t *testing.T) {
 	r, _ := http.NewRequest(http.MethodGet, "/user", nil)
 	w := httptest.NewRecorder()
 
 	handler := NewControllerRegister()
-	handler.RouterGet("/user", (*ExampleController).PingPointer)
+	handler.CtrlGet("/user", (*ExampleController).PingPointer)
 	handler.ServeHTTP(w, r)
 	if w.Body.String() != examplePointerBody {
-		t.Errorf("TestRouterRouterGetPointerMethod can't run")
+		t.Errorf("TestRouterCtrlGetPointerMethod can't run")
 	}
 }
 
-func TestRouterRouterPostPointerMethod(t *testing.T) {
+func TestRouterCtrlPostPointerMethod(t *testing.T) {
 	r, _ := http.NewRequest(http.MethodPost, "/user", nil)
 	w := httptest.NewRecorder()
 
 	handler := NewControllerRegister()
-	handler.RouterPost("/user", (*ExampleController).PingPointer)
+	handler.CtrlPost("/user", (*ExampleController).PingPointer)
 	handler.ServeHTTP(w, r)
 	if w.Body.String() != examplePointerBody {
-		t.Errorf("TestRouterRouterPostPointerMethod can't run")
+		t.Errorf("TestRouterCtrlPostPointerMethod can't run")
 	}
 }
 
-func TestRouterRouterHeadPointerMethod(t *testing.T) {
+func TestRouterCtrlHeadPointerMethod(t *testing.T) {
 	r, _ := http.NewRequest(http.MethodHead, "/user", nil)
 	w := httptest.NewRecorder()
 
 	handler := NewControllerRegister()
-	handler.RouterHead("/user", (*ExampleController).PingPointer)
+	handler.CtrlHead("/user", (*ExampleController).PingPointer)
 	handler.ServeHTTP(w, r)
 	if w.Body.String() != examplePointerBody {
-		t.Errorf("TestRouterRouterHeadPointerMethod can't run")
+		t.Errorf("TestRouterCtrlHeadPointerMethod can't run")
 	}
 }
 
-func TestRouterRouterPutPointerMethod(t *testing.T) {
+func TestRouterCtrlPutPointerMethod(t *testing.T) {
 	r, _ := http.NewRequest(http.MethodPut, "/user", nil)
 	w := httptest.NewRecorder()
 
 	handler := NewControllerRegister()
-	handler.RouterPut("/user", (*ExampleController).PingPointer)
+	handler.CtrlPut("/user", (*ExampleController).PingPointer)
 	handler.ServeHTTP(w, r)
 	if w.Body.String() != examplePointerBody {
-		t.Errorf("TestRouterRouterPutPointerMethod can't run")
+		t.Errorf("TestRouterCtrlPutPointerMethod can't run")
 	}
 }
 
-func TestRouterRouterPatchPointerMethod(t *testing.T) {
+func TestRouterCtrlPatchPointerMethod(t *testing.T) {
 	r, _ := http.NewRequest(http.MethodPatch, "/user", nil)
 	w := httptest.NewRecorder()
 
 	handler := NewControllerRegister()
-	handler.RouterPatch("/user", (*ExampleController).PingPointer)
+	handler.CtrlPatch("/user", (*ExampleController).PingPointer)
 	handler.ServeHTTP(w, r)
 	if w.Body.String() != examplePointerBody {
-		t.Errorf("TestRouterRouterPatchPointerMethod can't run")
+		t.Errorf("TestRouterCtrlPatchPointerMethod can't run")
 	}
 }
 
-func TestRouterRouterDeletePointerMethod(t *testing.T) {
+func TestRouterCtrlDeletePointerMethod(t *testing.T) {
 	r, _ := http.NewRequest(http.MethodDelete, "/user", nil)
 	w := httptest.NewRecorder()
 
 	handler := NewControllerRegister()
-	handler.RouterDelete("/user", (*ExampleController).PingPointer)
+	handler.CtrlDelete("/user", (*ExampleController).PingPointer)
 	handler.ServeHTTP(w, r)
 	if w.Body.String() != examplePointerBody {
-		t.Errorf("TestRouterRouterDeletePointerMethod can't run")
+		t.Errorf("TestRouterCtrlDeletePointerMethod can't run")
 	}
 }
 
-func TestRouterRouterAnyPointerMethod(t *testing.T) {
+func TestRouterCtrlAnyPointerMethod(t *testing.T) {
 	handler := NewControllerRegister()
-	handler.RouterAny("/user", (*ExampleController).PingPointer)
+	handler.CtrlAny("/user", (*ExampleController).PingPointer)
 
 	for method := range HTTPMETHOD {
 		w := httptest.NewRecorder()
 		r, _ := http.NewRequest(method, "/user", nil)
 		handler.ServeHTTP(w, r)
 		if w.Body.String() != examplePointerBody {
-			t.Errorf("TestRouterRouterAnyPointerMethod can't run, get the response is " + w.Body.String())
+			t.Errorf("TestRouterCtrlAnyPointerMethod can't run, get the response is " + w.Body.String())
 		}
 	}
 }

--- a/server/web/server.go
+++ b/server/web/server.go
@@ -619,7 +619,7 @@ func (app *HttpServer) CtrlAny(rootpath string, f interface{}) *HttpServer {
 }
 
 // Get see HttpServer.Get
-func Get(rootpath string, f FilterFunc) *HttpServer {
+func Get(rootpath string, f HandleFunc) *HttpServer {
 	return BeeApp.Get(rootpath, f)
 }
 
@@ -628,13 +628,13 @@ func Get(rootpath string, f FilterFunc) *HttpServer {
 //    beego.Get("/", func(ctx *context.Context){
 //          ctx.Output.Body("hello world")
 //    })
-func (app *HttpServer) Get(rootpath string, f FilterFunc) *HttpServer {
+func (app *HttpServer) Get(rootpath string, f HandleFunc) *HttpServer {
 	app.Handlers.Get(rootpath, f)
 	return app
 }
 
 // Post see HttpServer.Post
-func Post(rootpath string, f FilterFunc) *HttpServer {
+func Post(rootpath string, f HandleFunc) *HttpServer {
 	return BeeApp.Post(rootpath, f)
 }
 
@@ -643,13 +643,13 @@ func Post(rootpath string, f FilterFunc) *HttpServer {
 //    beego.Post("/api", func(ctx *context.Context){
 //          ctx.Output.Body("hello world")
 //    })
-func (app *HttpServer) Post(rootpath string, f FilterFunc) *HttpServer {
+func (app *HttpServer) Post(rootpath string, f HandleFunc) *HttpServer {
 	app.Handlers.Post(rootpath, f)
 	return app
 }
 
 // Delete see HttpServer.Delete
-func Delete(rootpath string, f FilterFunc) *HttpServer {
+func Delete(rootpath string, f HandleFunc) *HttpServer {
 	return BeeApp.Delete(rootpath, f)
 }
 
@@ -658,13 +658,13 @@ func Delete(rootpath string, f FilterFunc) *HttpServer {
 //    beego.Delete("/api", func(ctx *context.Context){
 //          ctx.Output.Body("hello world")
 //    })
-func (app *HttpServer) Delete(rootpath string, f FilterFunc) *HttpServer {
+func (app *HttpServer) Delete(rootpath string, f HandleFunc) *HttpServer {
 	app.Handlers.Delete(rootpath, f)
 	return app
 }
 
 // Put see HttpServer.Put
-func Put(rootpath string, f FilterFunc) *HttpServer {
+func Put(rootpath string, f HandleFunc) *HttpServer {
 	return BeeApp.Put(rootpath, f)
 }
 
@@ -673,13 +673,13 @@ func Put(rootpath string, f FilterFunc) *HttpServer {
 //    beego.Put("/api", func(ctx *context.Context){
 //          ctx.Output.Body("hello world")
 //    })
-func (app *HttpServer) Put(rootpath string, f FilterFunc) *HttpServer {
+func (app *HttpServer) Put(rootpath string, f HandleFunc) *HttpServer {
 	app.Handlers.Put(rootpath, f)
 	return app
 }
 
 // Head see HttpServer.Head
-func Head(rootpath string, f FilterFunc) *HttpServer {
+func Head(rootpath string, f HandleFunc) *HttpServer {
 	return BeeApp.Head(rootpath, f)
 }
 
@@ -688,13 +688,13 @@ func Head(rootpath string, f FilterFunc) *HttpServer {
 //    beego.Head("/api", func(ctx *context.Context){
 //          ctx.Output.Body("hello world")
 //    })
-func (app *HttpServer) Head(rootpath string, f FilterFunc) *HttpServer {
+func (app *HttpServer) Head(rootpath string, f HandleFunc) *HttpServer {
 	app.Handlers.Head(rootpath, f)
 	return app
 }
 
 // Options see HttpServer.Options
-func Options(rootpath string, f FilterFunc) *HttpServer {
+func Options(rootpath string, f HandleFunc) *HttpServer {
 	BeeApp.Handlers.Options(rootpath, f)
 	return BeeApp
 }
@@ -704,13 +704,13 @@ func Options(rootpath string, f FilterFunc) *HttpServer {
 //    beego.Options("/api", func(ctx *context.Context){
 //          ctx.Output.Body("hello world")
 //    })
-func (app *HttpServer) Options(rootpath string, f FilterFunc) *HttpServer {
+func (app *HttpServer) Options(rootpath string, f HandleFunc) *HttpServer {
 	app.Handlers.Options(rootpath, f)
 	return app
 }
 
 // Patch see HttpServer.Patch
-func Patch(rootpath string, f FilterFunc) *HttpServer {
+func Patch(rootpath string, f HandleFunc) *HttpServer {
 	return BeeApp.Patch(rootpath, f)
 }
 
@@ -719,13 +719,13 @@ func Patch(rootpath string, f FilterFunc) *HttpServer {
 //    beego.Patch("/api", func(ctx *context.Context){
 //          ctx.Output.Body("hello world")
 //    })
-func (app *HttpServer) Patch(rootpath string, f FilterFunc) *HttpServer {
+func (app *HttpServer) Patch(rootpath string, f HandleFunc) *HttpServer {
 	app.Handlers.Patch(rootpath, f)
 	return app
 }
 
 // Any see HttpServer.Any
-func Any(rootpath string, f FilterFunc) *HttpServer {
+func Any(rootpath string, f HandleFunc) *HttpServer {
 	return BeeApp.Any(rootpath, f)
 }
 
@@ -734,7 +734,7 @@ func Any(rootpath string, f FilterFunc) *HttpServer {
 //    beego.Any("/api", func(ctx *context.Context){
 //          ctx.Output.Body("hello world")
 //    })
-func (app *HttpServer) Any(rootpath string, f FilterFunc) *HttpServer {
+func (app *HttpServer) Any(rootpath string, f HandleFunc) *HttpServer {
 	app.Handlers.Any(rootpath, f)
 	return app
 }

--- a/server/web/server.go
+++ b/server/web/server.go
@@ -458,12 +458,12 @@ func (app *HttpServer) AutoPrefix(prefix string, c ControllerInterface) *HttpSer
 	return app
 }
 
-// RouterGet see HttpServer.RouterGet
-func RouterGet(rootpath string, f interface{}) {
-	BeeApp.RouterGet(rootpath, f)
+// CtrlGet see HttpServer.CtrlGet
+func CtrlGet(rootpath string, f interface{}) {
+	BeeApp.CtrlGet(rootpath, f)
 }
 
-// RouterGet used to register router for RouterGet method
+// CtrlGet used to register router for CtrlGet method
 // usage:
 //    type MyController struct {
 //	     web.Controller
@@ -472,18 +472,18 @@ func RouterGet(rootpath string, f interface{}) {
 //	     m.Ctx.Output.Body([]byte("hello world"))
 //    }
 //
-//    RouterGet("/api/:id", MyController.Ping)
-func (app *HttpServer) RouterGet(rootpath string, f interface{}) *HttpServer {
-	app.Handlers.RouterGet(rootpath, f)
+//    CtrlGet("/api/:id", MyController.Ping)
+func (app *HttpServer) CtrlGet(rootpath string, f interface{}) *HttpServer {
+	app.Handlers.CtrlGet(rootpath, f)
 	return app
 }
 
-// RouterPost see HttpServer.RouterGet
-func RouterPost(rootpath string, f interface{}) {
-	BeeApp.RouterPost(rootpath, f)
+// CtrlPost see HttpServer.CtrlGet
+func CtrlPost(rootpath string, f interface{}) {
+	BeeApp.CtrlPost(rootpath, f)
 }
 
-// RouterPost used to register router for RouterPost method
+// CtrlPost used to register router for CtrlPost method
 // usage:
 //    type MyController struct {
 //	     web.Controller
@@ -492,18 +492,18 @@ func RouterPost(rootpath string, f interface{}) {
 //	     m.Ctx.Output.Body([]byte("hello world"))
 //    }
 //
-//    RouterPost("/api/:id", MyController.Ping)
-func (app *HttpServer) RouterPost(rootpath string, f interface{}) *HttpServer {
-	app.Handlers.RouterPost(rootpath, f)
+//    CtrlPost("/api/:id", MyController.Ping)
+func (app *HttpServer) CtrlPost(rootpath string, f interface{}) *HttpServer {
+	app.Handlers.CtrlPost(rootpath, f)
 	return app
 }
 
-// RouterHead see HttpServer.RouterHead
-func RouterHead(rootpath string, f interface{}) {
-	BeeApp.RouterHead(rootpath, f)
+// CtrlHead see HttpServer.CtrlHead
+func CtrlHead(rootpath string, f interface{}) {
+	BeeApp.CtrlHead(rootpath, f)
 }
 
-// RouterHead used to register router for RouterHead method
+// CtrlHead used to register router for CtrlHead method
 // usage:
 //    type MyController struct {
 //	     web.Controller
@@ -512,18 +512,18 @@ func RouterHead(rootpath string, f interface{}) {
 //	     m.Ctx.Output.Body([]byte("hello world"))
 //    }
 //
-//    RouterHead("/api/:id", MyController.Ping)
-func (app *HttpServer) RouterHead(rootpath string, f interface{}) *HttpServer {
-	app.Handlers.RouterHead(rootpath, f)
+//    CtrlHead("/api/:id", MyController.Ping)
+func (app *HttpServer) CtrlHead(rootpath string, f interface{}) *HttpServer {
+	app.Handlers.CtrlHead(rootpath, f)
 	return app
 }
 
-// RouterPut see HttpServer.RouterPut
-func RouterPut(rootpath string, f interface{}) {
-	BeeApp.RouterPut(rootpath, f)
+// CtrlPut see HttpServer.CtrlPut
+func CtrlPut(rootpath string, f interface{}) {
+	BeeApp.CtrlPut(rootpath, f)
 }
 
-// RouterPut used to register router for RouterPut method
+// CtrlPut used to register router for CtrlPut method
 // usage:
 //    type MyController struct {
 //	     web.Controller
@@ -532,18 +532,18 @@ func RouterPut(rootpath string, f interface{}) {
 //	     m.Ctx.Output.Body([]byte("hello world"))
 //    }
 //
-//    RouterPut("/api/:id", MyController.Ping)
-func (app *HttpServer) RouterPut(rootpath string, f interface{}) *HttpServer {
-	app.Handlers.RouterPut(rootpath, f)
+//    CtrlPut("/api/:id", MyController.Ping)
+func (app *HttpServer) CtrlPut(rootpath string, f interface{}) *HttpServer {
+	app.Handlers.CtrlPut(rootpath, f)
 	return app
 }
 
-// RouterPatch see HttpServer.RouterPatch
-func RouterPatch(rootpath string, f interface{}) {
-	BeeApp.RouterPatch(rootpath, f)
+// CtrlPatch see HttpServer.CtrlPatch
+func CtrlPatch(rootpath string, f interface{}) {
+	BeeApp.CtrlPatch(rootpath, f)
 }
 
-// RouterPatch used to register router for RouterPatch method
+// CtrlPatch used to register router for CtrlPatch method
 // usage:
 //    type MyController struct {
 //	     web.Controller
@@ -552,18 +552,18 @@ func RouterPatch(rootpath string, f interface{}) {
 //	     m.Ctx.Output.Body([]byte("hello world"))
 //    }
 //
-//    RouterPatch("/api/:id", MyController.Ping)
-func (app *HttpServer) RouterPatch(rootpath string, f interface{}) *HttpServer {
-	app.Handlers.RouterPatch(rootpath, f)
+//    CtrlPatch("/api/:id", MyController.Ping)
+func (app *HttpServer) CtrlPatch(rootpath string, f interface{}) *HttpServer {
+	app.Handlers.CtrlPatch(rootpath, f)
 	return app
 }
 
-// RouterDelete see HttpServer.RouterDelete
-func RouterDelete(rootpath string, f interface{}) {
-	BeeApp.RouterDelete(rootpath, f)
+// CtrlDelete see HttpServer.CtrlDelete
+func CtrlDelete(rootpath string, f interface{}) {
+	BeeApp.CtrlDelete(rootpath, f)
 }
 
-// RouterDelete used to register router for RouterDelete method
+// CtrlDelete used to register router for CtrlDelete method
 // usage:
 //    type MyController struct {
 //	     web.Controller
@@ -572,18 +572,18 @@ func RouterDelete(rootpath string, f interface{}) {
 //	     m.Ctx.Output.Body([]byte("hello world"))
 //    }
 //
-//    RouterDelete("/api/:id", MyController.Ping)
-func (app *HttpServer) RouterDelete(rootpath string, f interface{}) *HttpServer {
-	app.Handlers.RouterDelete(rootpath, f)
+//    CtrlDelete("/api/:id", MyController.Ping)
+func (app *HttpServer) CtrlDelete(rootpath string, f interface{}) *HttpServer {
+	app.Handlers.CtrlDelete(rootpath, f)
 	return app
 }
 
-// RouterOptions see HttpServer.RouterOptions
-func RouterOptions(rootpath string, f interface{}) {
-	BeeApp.RouterOptions(rootpath, f)
+// CtrlOptions see HttpServer.CtrlOptions
+func CtrlOptions(rootpath string, f interface{}) {
+	BeeApp.CtrlOptions(rootpath, f)
 }
 
-// RouterOptions used to register router for RouterOptions method
+// CtrlOptions used to register router for CtrlOptions method
 // usage:
 //    type MyController struct {
 //	     web.Controller
@@ -592,18 +592,18 @@ func RouterOptions(rootpath string, f interface{}) {
 //	     m.Ctx.Output.Body([]byte("hello world"))
 //    }
 //
-//    RouterOptions("/api/:id", MyController.Ping)
-func (app *HttpServer) RouterOptions(rootpath string, f interface{}) *HttpServer {
-	app.Handlers.RouterOptions(rootpath, f)
+//    CtrlOptions("/api/:id", MyController.Ping)
+func (app *HttpServer) CtrlOptions(rootpath string, f interface{}) *HttpServer {
+	app.Handlers.CtrlOptions(rootpath, f)
 	return app
 }
 
-// RouterAny see HttpServer.RouterAny
-func RouterAny(rootpath string, f interface{}) {
-	BeeApp.RouterAny(rootpath, f)
+// CtrlAny see HttpServer.CtrlAny
+func CtrlAny(rootpath string, f interface{}) {
+	BeeApp.CtrlAny(rootpath, f)
 }
 
-// RouterAny used to register router for RouterAny method
+// CtrlAny used to register router for CtrlAny method
 // usage:
 //    type MyController struct {
 //	     web.Controller
@@ -612,9 +612,9 @@ func RouterAny(rootpath string, f interface{}) {
 //	     m.Ctx.Output.Body([]byte("hello world"))
 //    }
 //
-//    RouterAny("/api/:id", MyController.Ping)
-func (app *HttpServer) RouterAny(rootpath string, f interface{}) *HttpServer {
-	app.Handlers.RouterAny(rootpath, f)
+//    CtrlAny("/api/:id", MyController.Ping)
+func (app *HttpServer) CtrlAny(rootpath string, f interface{}) *HttpServer {
+	app.Handlers.CtrlAny(rootpath, f)
 	return app
 }
 

--- a/server/web/server_test.go
+++ b/server/web/server_test.go
@@ -29,81 +29,81 @@ func TestNewHttpServerWithCfg(t *testing.T) {
 	assert.Equal(t, "hello", BConfig.AppName)
 }
 
-func TestServerRouterGet(t *testing.T) {
+func TestServerCtrlGet(t *testing.T) {
 	r, _ := http.NewRequest(http.MethodGet, "/user", nil)
 	w := httptest.NewRecorder()
 
-	RouterGet("/user", ExampleController.Ping)
+	CtrlGet("/user", ExampleController.Ping)
 	BeeApp.Handlers.ServeHTTP(w, r)
 	if w.Body.String() != exampleBody {
-		t.Errorf("TestServerRouterGet can't run")
+		t.Errorf("TestServerCtrlGet can't run")
 	}
 }
 
-func TestServerRouterPost(t *testing.T) {
+func TestServerCtrlPost(t *testing.T) {
 	r, _ := http.NewRequest(http.MethodPost, "/user", nil)
 	w := httptest.NewRecorder()
 
-	RouterPost("/user", ExampleController.Ping)
+	CtrlPost("/user", ExampleController.Ping)
 	BeeApp.Handlers.ServeHTTP(w, r)
 	if w.Body.String() != exampleBody {
-		t.Errorf("TestServerRouterPost can't run")
+		t.Errorf("TestServerCtrlPost can't run")
 	}
 }
 
-func TestServerRouterHead(t *testing.T) {
+func TestServerCtrlHead(t *testing.T) {
 	r, _ := http.NewRequest(http.MethodHead, "/user", nil)
 	w := httptest.NewRecorder()
 
-	RouterHead("/user", ExampleController.Ping)
+	CtrlHead("/user", ExampleController.Ping)
 	BeeApp.Handlers.ServeHTTP(w, r)
 	if w.Body.String() != exampleBody {
-		t.Errorf("TestServerRouterHead can't run")
+		t.Errorf("TestServerCtrlHead can't run")
 	}
 }
 
-func TestServerRouterPut(t *testing.T) {
+func TestServerCtrlPut(t *testing.T) {
 	r, _ := http.NewRequest(http.MethodPut, "/user", nil)
 	w := httptest.NewRecorder()
 
-	RouterPut("/user", ExampleController.Ping)
+	CtrlPut("/user", ExampleController.Ping)
 	BeeApp.Handlers.ServeHTTP(w, r)
 	if w.Body.String() != exampleBody {
-		t.Errorf("TestServerRouterPut can't run")
+		t.Errorf("TestServerCtrlPut can't run")
 	}
 }
 
-func TestServerRouterPatch(t *testing.T) {
+func TestServerCtrlPatch(t *testing.T) {
 	r, _ := http.NewRequest(http.MethodPatch, "/user", nil)
 	w := httptest.NewRecorder()
 
-	RouterPatch("/user", ExampleController.Ping)
+	CtrlPatch("/user", ExampleController.Ping)
 	BeeApp.Handlers.ServeHTTP(w, r)
 	if w.Body.String() != exampleBody {
-		t.Errorf("TestServerRouterPatch can't run")
+		t.Errorf("TestServerCtrlPatch can't run")
 	}
 }
 
-func TestServerRouterDelete(t *testing.T) {
+func TestServerCtrlDelete(t *testing.T) {
 	r, _ := http.NewRequest(http.MethodDelete, "/user", nil)
 	w := httptest.NewRecorder()
 
-	RouterDelete("/user", ExampleController.Ping)
+	CtrlDelete("/user", ExampleController.Ping)
 	BeeApp.Handlers.ServeHTTP(w, r)
 	if w.Body.String() != exampleBody {
-		t.Errorf("TestServerRouterDelete can't run")
+		t.Errorf("TestServerCtrlDelete can't run")
 	}
 }
 
-func TestServerRouterAny(t *testing.T) {
-	RouterAny("/user", ExampleController.Ping)
+func TestServerCtrlAny(t *testing.T) {
+	CtrlAny("/user", ExampleController.Ping)
 
 	for method := range HTTPMETHOD {
 		r, _ := http.NewRequest(method, "/user", nil)
 		w := httptest.NewRecorder()
 		BeeApp.Handlers.ServeHTTP(w, r)
 		if w.Body.String() != exampleBody {
-			t.Errorf("TestServerRouterAny can't run")
+			t.Errorf("TestServerCtrlAny can't run")
 		}
 	}
 }


### PR DESCRIPTION
1. Add comments for BConfig
2. Rename `RouterXXX` to `CtrlXXX`. I think `RouterXXX` is not clear enough because I want users notice that there are two major styles of registering router. One is `web.Get`, `web.Post`..., the functional style. Another is `web.CtrlXXX` which depends on MVC, the `Controller`. The `RouterXXX` is not released to users, so it could be renamed.
3. Now, the functions `web.XXX` accepts `FilterFunc` as parameter, but it makes users confused, so I define a new type `HandleFunc`, it's the same with original `FilterFunc`. And then I make `FilterFunc` as an alias of `HandleFunc`. 
 