### PR TITLE
修正：XSRFToken函数在特定情况下会产生多个不同Path的_xsrf同名cookie

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@
 - Add comments to `web.Config`, rename `RouterXXX` to `CtrlXXX`, define `HandleFunc` [4714](https://github.com/beego/beego/pull/4714)
 - Refactor: Move `BindXXX` and `XXXResp` methods to `context.Context`. [4718](https://github.com/beego/beego/pull/4718)
 - fix bug:reflect.ValueOf(nil) in getFlatParams [4715](https://github.com/beego/beego/pull/4715)
+- Fix 4736: set a fixed value "/" to the "Path" of "_xsrf" cookie. [4736](https://github.com/beego/beego/issues/4735)
 
 ## Fix Sonar
 

--- a/server/web/context/context.go
+++ b/server/web/context/context.go
@@ -270,7 +270,7 @@ func (ctx *Context) XSRFToken(key string, expire int64) string {
 		if !ok {
 			token = string(utils.RandomCreateBytes(32))
 			// TODO make it configurable
-			ctx.SetSecureCookie(key, "_xsrf", token, expire, "", "")
+			ctx.SetSecureCookie(key, "_xsrf", token, expire, "/", "")
 		}
 		ctx._xsrfToken = token
 	}


### PR DESCRIPTION
#4735 
例如：访问”/login“页面，有个表单，此时会产生一个_xsrf cookie，Path为”/“，此时手动删除_xsrf cookie，Post提交到“/test/post”，会报错expected XSRF not found；后退到”/login“页面，会产生一个Path为”/login“的_xsrf cookie，然后访问"/"根页面，再回到"/login"页面，这时会产生两个_xsrf cookie，Path分别为"/"和”/login"，再向"/test/post"页面提交，后端就可能读到错误的_xsrf cookie造成XSRF验证失败。
在XSRFToken函数中，将SetSecureCookie函数中的Path参数固定为"/"，可以解决这个问题