### PR TITLE
set a default value "/" for "Path" in the Cookie function when there is not parameter "Path" or the parameter is ""

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@
 - fix bug:reflect.ValueOf(nil) in getFlatParams [4715](https://github.com/beego/beego/pull/4715)
 - Fix 4736: set a fixed value "/" to the "Path" of "_xsrf" cookie. [4736](https://github.com/beego/beego/issues/4735)
 - Fix 4734: do not reset id in Delete function. [4738](https://github.com/beego/beego/pull/4738)
+- Fix 4739: set a default value "/" for "Path" in the Cookie function when there is not parameter "Path" or the parameter is "". [4739](https://github.com/beego/beego/issues/4739)
 
 ## Fix Sonar
 

--- a/server/web/context/output.go
+++ b/server/web/context/output.go
@@ -118,13 +118,13 @@ func (output *BeegoOutput) Cookie(name string, value string, others ...interface
 	// can use nil skip set
 
 	// default "/"
+	tmpPath := "/"
 	if len(others) > 1 {
 		if v, ok := others[1].(string); ok && len(v) > 0 {
-			fmt.Fprintf(&b, "; Path=%s", sanitizeValue(v))
+			tmpPath = sanitizeValue(v)
 		}
-	} else {
-		fmt.Fprintf(&b, "; Path=%s", "/")
 	}
+	fmt.Fprintf(&b, "; Path=%s", tmpPath)
 
 	// default empty
 	if len(others) > 2 {


### PR DESCRIPTION
fix #4739: set a default value "/" for "Path" in the Cookie function when there is no parameter "Path" or the parameter is "". And a better way to fix #4736 