### PR TITLE
fix numeric notation of permissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,7 @@
 - Fix 4699: Remove Remove goyaml2 dependency. [4755](https://github.com/beego/beego/pull/4755)
 - Fix 4698: Prompt error when config format is incorrect. [4757](https://github.com/beego/beego/pull/4757)
 - Fix 4674: Tx Orm missing debug log [4756](https://github.com/beego/beego/pull/4756)
+- Fix 4759: fix numeric notation of permissions [4759](https://github.com/beego/beego/pull/4759)
 ## Fix Sonar
 
 - [4677](https://github.com/beego/beego/pull/4677)

--- a/core/logs/file.go
+++ b/core/logs/file.go
@@ -136,7 +136,7 @@ func (w *fileLogWriter) Init(config string) error {
 	if len(w.Formatter) > 0 {
 		fmtr, ok := GetFormatter(w.Formatter)
 		if !ok {
-			return errors.New(fmt.Sprintf("the formatter with name: %s not found", w.Formatter))
+			return fmt.Errorf("the formatter with name: %s not found", w.Formatter)
 		}
 		w.formatter = fmtr
 	}

--- a/core/logs/file.go
+++ b/core/logs/file.go
@@ -66,7 +66,7 @@ type fileLogWriter struct {
 	Level int `json:"level"`
 	// Permissions for log file
 	Perm string `json:"perm"`
-	// Permissions for directory if it is spcified in FileName
+	// Permissions for directory if it is specified in FileName
 	DirPerm string `json:"dirperm"`
 
 	RotatePerm string `json:"rotateperm"`

--- a/core/logs/file.go
+++ b/core/logs/file.go
@@ -64,9 +64,9 @@ type fileLogWriter struct {
 	hourlyOpenTime time.Time
 
 	Level int `json:"level"`
-
+	// Permissions for log file
 	Perm string `json:"perm"`
-
+	// Permissions for directory if it is spcified in FileName
 	DirPerm string `json:"dirperm"`
 
 	RotatePerm string `json:"rotateperm"`

--- a/core/logs/file.go
+++ b/core/logs/file.go
@@ -97,7 +97,7 @@ func newFileWriter() Logger {
 	return w
 }
 
-func (w *fileLogWriter) Format(lm *LogMsg) string {
+func (*fileLogWriter) Format(lm *LogMsg) string {
 	msg := lm.OldStyleFormat()
 	hd, _, _ := formatTimeHeader(lm.When)
 	msg = fmt.Sprintf("%s %s\n", string(hd), msg)

--- a/core/logs/file.go
+++ b/core/logs/file.go
@@ -124,7 +124,7 @@ func (w *fileLogWriter) Init(config string) error {
 	if err != nil {
 		return err
 	}
-	if len(w.Filename) == 0 {
+	if w.Filename == "" {
 		return errors.New("jsonconfig must have filename")
 	}
 	w.suffix = filepath.Ext(w.Filename)

--- a/core/logs/file.go
+++ b/core/logs/file.go
@@ -73,8 +73,8 @@ type fileLogWriter struct {
 
 	fileNameOnly, suffix string // like "project.log", project is fileNameOnly and .log is suffix
 
-	formatter LogFormatter
-	Formatter string `json:"formatter"`
+	logFormatter LogFormatter
+	Formatter    string `json:"formatter"`
 }
 
 // newFileWriter creates a FileLogWriter returning as LoggerInterface.
@@ -93,7 +93,7 @@ func newFileWriter() Logger {
 		MaxFiles:   999,
 		MaxSize:    1 << 28,
 	}
-	w.formatter = w
+	w.logFormatter = w
 	return w
 }
 
@@ -105,7 +105,7 @@ func (*fileLogWriter) Format(lm *LogMsg) string {
 }
 
 func (w *fileLogWriter) SetFormatter(f LogFormatter) {
-	w.formatter = f
+	w.logFormatter = f
 }
 
 // Init file logger with json config.
@@ -138,7 +138,7 @@ func (w *fileLogWriter) Init(config string) error {
 		if !ok {
 			return fmt.Errorf("the formatter with name: %s not found", w.Formatter)
 		}
-		w.formatter = fmtr
+		w.logFormatter = fmtr
 	}
 	err = w.startLogger()
 	return err
@@ -177,7 +177,7 @@ func (w *fileLogWriter) WriteMsg(lm *LogMsg) error {
 
 	_, d, h := formatTimeHeader(lm.When)
 
-	msg := w.formatter.Format(lm)
+	msg := w.logFormatter.Format(lm)
 	if w.Rotate {
 		w.RLock()
 		if w.needRotateHourly(h) {

--- a/core/logs/file.go
+++ b/core/logs/file.go
@@ -67,6 +67,8 @@ type fileLogWriter struct {
 
 	Perm string `json:"perm"`
 
+	DirPerm string `json:"dirperm"`
+
 	RotatePerm string `json:"rotateperm"`
 
 	fileNameOnly, suffix string // like "project.log", project is fileNameOnly and .log is suffix
@@ -86,6 +88,7 @@ func newFileWriter() Logger {
 		RotatePerm: "0440",
 		Level:      LevelTrace,
 		Perm:       "0660",
+		DirPerm:    "0770",
 		MaxLines:   10000000,
 		MaxFiles:   999,
 		MaxSize:    1 << 28,
@@ -217,8 +220,13 @@ func (w *fileLogWriter) createLogFile() (*os.File, error) {
 		return nil, err
 	}
 
+	dirperm, err := strconv.ParseInt(w.DirPerm, 8, 64)
+	if err != nil {
+		return nil, err
+	}
+
 	filepath := path.Dir(w.Filename)
-	os.MkdirAll(filepath, os.FileMode(perm))
+	os.MkdirAll(filepath, os.FileMode(dirperm))
 
 	fd, err := os.OpenFile(w.Filename, os.O_WRONLY|os.O_APPEND|os.O_CREATE, os.FileMode(perm))
 	if err == nil {

--- a/core/logs/file_test.go
+++ b/core/logs/file_test.go
@@ -69,7 +69,7 @@ func TestFileWithPrefixPath(t *testing.T) {
 
 func TestFilePermWithPrefixPath(t *testing.T) {
 	log := NewLogger(10000)
-	log.SetLogger("file", `{"filename":"log/test.log", "perm": "0220", "dirperm": "0770"}`)
+	log.SetLogger("file", `{"filename":"mylogpath/test.log", "perm": "0220", "dirperm": "0770"}`)
 	log.Debug("debug")
 	log.Informational("info")
 	log.Notice("notice")
@@ -79,15 +79,15 @@ func TestFilePermWithPrefixPath(t *testing.T) {
 	log.Critical("critical")
 	log.Emergency("emergency")
 
-	dir, err := os.Stat("log")
+	dir, err := os.Stat("mylogpath")
 	if err != nil {
 		t.Fatal(err)
 	}
-	if dir.Mode().Perm() != 0o0770 {
-		t.Fatal("unexpected directory permission")
+	if !dir.IsDir() {
+		t.Fatal("mylogpath expected to be a directory")
 	}
 
-	file, err := os.Stat("log/test.log")
+	file, err := os.Stat("mylogpath/test.log")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -95,8 +95,8 @@ func TestFilePermWithPrefixPath(t *testing.T) {
 		t.Fatal("unexpected file permission")
 	}
 
-	os.Remove("log/test.log")
-	os.Remove("log")
+	os.Remove("mylogpath/test.log")
+	os.Remove("mylogpath")
 }
 
 func TestFile1(t *testing.T) {

--- a/core/logs/file_test.go
+++ b/core/logs/file_test.go
@@ -324,7 +324,7 @@ func testFileRotate(t *testing.T, fn1, fn2 string, daily, hourly bool) {
 		DirPerm:    "0770",
 		RotatePerm: "0440",
 	}
-	fw.formatter = fw
+	fw.logFormatter = fw
 
 	if daily {
 		fw.Init(fmt.Sprintf(`{"filename":"%v","maxdays":1}`, fn1))
@@ -366,7 +366,7 @@ func testFileDailyRotate(t *testing.T, fn1, fn2 string) {
 		DirPerm:    "0770",
 		RotatePerm: "0440",
 	}
-	fw.formatter = fw
+	fw.logFormatter = fw
 
 	fw.Init(fmt.Sprintf(`{"filename":"%v","maxdays":1}`, fn1))
 	fw.dailyOpenTime = time.Now().Add(-24 * time.Hour)
@@ -402,7 +402,7 @@ func testFileHourlyRotate(t *testing.T, fn1, fn2 string) {
 		RotatePerm: "0440",
 	}
 
-	fw.formatter = fw
+	fw.logFormatter = fw
 	fw.Init(fmt.Sprintf(`{"filename":"%v","maxhours":1}`, fn1))
 	fw.hourlyOpenTime = time.Now().Add(-1 * time.Hour)
 	fw.hourlyOpenDate = fw.hourlyOpenTime.Hour()

--- a/core/logs/file_test.go
+++ b/core/logs/file_test.go
@@ -326,13 +326,13 @@ func testFileRotate(t *testing.T, fn1, fn2 string, daily, hourly bool) {
 	}
 	fw.logFormatter = fw
 
-	if daily {
+	if fw.Daily {
 		fw.Init(fmt.Sprintf(`{"filename":"%v","maxdays":1}`, fn1))
 		fw.dailyOpenTime = time.Now().Add(-24 * time.Hour)
 		fw.dailyOpenDate = fw.dailyOpenTime.Day()
 	}
 
-	if hourly {
+	if fw.Hourly {
 		fw.Init(fmt.Sprintf(`{"filename":"%v","maxhours":1}`, fn1))
 		fw.hourlyOpenTime = time.Now().Add(-1 * time.Hour)
 		fw.hourlyOpenDate = fw.hourlyOpenTime.Day()

--- a/core/logs/file_test.go
+++ b/core/logs/file_test.go
@@ -17,7 +17,6 @@ package logs
 import (
 	"bufio"
 	"fmt"
-	"io/fs"
 	"io/ioutil"
 	"os"
 	"strconv"
@@ -84,7 +83,7 @@ func TestFilePermWithPrefixPath(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if fs.ModePerm&dir.Mode() != 0o0770 {
+	if dir.Mode().Perm() != 0o0770 {
 		t.Fatal("unexpected directory permission")
 	}
 


### PR DESCRIPTION
Create a directory without _execute_ permission  is problematic , since we can not access that directory.

For example, the following case 
`logs.SetLogger(logs.AdapterFile, `{"filename":"log/test.log"}`)`

we will get a **permission denied** error

more detail :
[https://en.wikipedia.org/wiki/File-system_permissions#Numeric_notation](wiki)