### PR TITLE
SCC-S1023 Redundant control flow fix

### DIFF
--- a/client/orm/models.go
+++ b/client/orm/models.go
@@ -325,7 +325,6 @@ end:
 		debug.PrintStack()
 	}
 	mc.done = true
-	return
 }
 
 // register register models to model cache


### PR DESCRIPTION
A good practice is to not use the "return" statement at the end. 