### PR TITLE
fix unexpected result on 'One' Function in orm

### DIFF
--- a/client/orm/orm_queryset.go
+++ b/client/orm/orm_queryset.go
@@ -287,7 +287,7 @@ func (o *querySet) One(container interface{}, cols ...string) error {
 }
 
 func (o *querySet) OneWithCtx(ctx context.Context, container interface{}, cols ...string) error {
-	o.limit = 1
+	//o.limit = 1
 	num, err := o.orm.alias.DbBaser.ReadBatch(ctx, o.orm.db, o, o.mi, o.cond, container, o.orm.alias.TZ, cols)
 	if err != nil {
 		return err


### PR DESCRIPTION
'One' Funcition was expected to act like returning ErrMultiRows, but if we put limit 1 in sql script, it seems that it will never return ErrMultiRows but return the first one record instead.
It seems a bug.