### PR TITLE
Start response automatically when hijacked

### DIFF
--- a/server/web/context/context.go
+++ b/server/web/context/context.go
@@ -373,9 +373,11 @@ func (r *Response) Hijack() (net.Conn, *bufio.ReadWriter, error) {
 		return nil, nil, errors.New("webserver doesn't support hijacking")
 	}
 	conn, rw, err := hj.Hijack()
-	//if err == nil {
-	//	r.Started = true
-	//}
+	if err == nil {
+		// If the response writer isn't started, router attempts to find a template to render but panics as there isn't
+		// any in most of the cases.
+		r.Started = true
+	}
 	return conn, rw, err
 }
 

--- a/server/web/context/context.go
+++ b/server/web/context/context.go
@@ -373,9 +373,9 @@ func (r *Response) Hijack() (net.Conn, *bufio.ReadWriter, error) {
 		return nil, nil, errors.New("webserver doesn't support hijacking")
 	}
 	conn, rw, err := hj.Hijack()
-	if err == nil {
-		r.Started = true
-	}
+	//if err == nil {
+	//	r.Started = true
+	//}
 	return conn, rw, err
 }
 

--- a/server/web/context/context.go
+++ b/server/web/context/context.go
@@ -372,7 +372,11 @@ func (r *Response) Hijack() (net.Conn, *bufio.ReadWriter, error) {
 	if !ok {
 		return nil, nil, errors.New("webserver doesn't support hijacking")
 	}
-	return hj.Hijack()
+	conn, rw, err := hj.Hijack()
+	if err == nil {
+		r.Started = true
+	}
+	return conn, rw, err
 }
 
 // Flush http.Flusher

--- a/server/web/router_test.go
+++ b/server/web/router_test.go
@@ -1141,8 +1141,8 @@ func TestHijacking(t *testing.T) {
 	handler.Add("/hijack", &HijackingController{})
 	handler.ServeHTTP(w, r)
 
-	// If the response writer wasn't started, codes above attempts to find a template to render but panics as there
-	// isn't any. Router then recovers and sets status to 500 automatically.
+	// If the response writer wasn't started, router attempts to find a template to render but panics as there isn't
+	// any. Router then recovers and sets status to 500 automatically.
 	if w.StatusCode != 0 {
 		t.Errorf("Hijacking failed with status %d", w.StatusCode)
 	}


### PR DESCRIPTION
Beego router will try to find and render the template automatically after executing the controller, if the response writer (in fact a response object) hasn't been started. 

https://github.com/beego/beego/blob/b3e78c97d7e4eb076d8dc05724e3fee2f73c9b34/server/web/router.go#L1210-L1215

This is reasonable for usual HTTP request because the response writer is started automatically when controller writes any bytes. But if controller hijacks the connection, e. g. WebSocket case, it will use the underlying connection directly and the response writer does not start automatically. When request handling is completed, Beego router tries to render template but there usually aren't be any as hijacking means controller would takeover the connection completely. Eventually a panic happens.

This change starts the request writer automatically when it is hijacked to avoid such issue.