### PR TITLE
Feature: Add custom TLSConfig 增加一个自定义参数，用于tls配置

### DIFF
--- a/server/web/config.go
+++ b/server/web/config.go
@@ -242,6 +242,10 @@ type Listen struct {
 	// The default value is tls.RequireAndVerifyClientCert
 	// @Default 4
 	ClientAuth int
+	// @Description Beego use this tls.Config to initialize TLS connection if not nil
+	// The default value is nil
+	// @Default nil
+	CustomTLSConfig *tls.Config
 }
 
 // WebConfig holds web related config

--- a/server/web/server.go
+++ b/server/web/server.go
@@ -166,6 +166,11 @@ func (app *HttpServer) Run(addr string, mws ...MiddleWare) {
 						app.Server.TLSConfig = &tls.Config{GetCertificate: m.GetCertificate}
 						app.Cfg.Listen.HTTPSCertFile, app.Cfg.Listen.HTTPSKeyFile = "", ""
 					}
+					// CustomTLSConfig has the highest priority, be careful!
+					// You need to give all config about TLS.
+					if app.Cfg.Listen.CustomTLSConfig != nil {
+						app.Server.TLSConfig = app.Cfg.Listen.CustomTLSConfig
+					}
 					if err := server.ListenAndServeTLS(app.Cfg.Listen.HTTPSCertFile, app.Cfg.Listen.HTTPSKeyFile); err != nil {
 						logs.Critical("ListenAndServeTLS: ", err, fmt.Sprintf("%d", os.Getpid()))
 						time.Sleep(100 * time.Microsecond)
@@ -224,6 +229,11 @@ func (app *HttpServer) Run(addr string, mws ...MiddleWare) {
 					ClientCAs:  pool,
 					ClientAuth: tls.ClientAuthType(app.Cfg.Listen.ClientAuth),
 				}
+			}
+			// CustomTLSConfig has the highest priority, be careful!
+			// You need to give all config about TLS.
+			if app.Cfg.Listen.CustomTLSConfig != nil {
+				app.Server.TLSConfig = app.Cfg.Listen.CustomTLSConfig
 			}
 			if err := app.Server.ListenAndServeTLS(app.Cfg.Listen.HTTPSCertFile, app.Cfg.Listen.HTTPSKeyFile); err != nil {
 				logs.Critical("ListenAndServeTLS: ", err)


### PR DESCRIPTION
CusdomTLSConfig is advanced configuration for tls. it is nil by default and compatible with the current state.
CusdomTLSConfig是一个高阶配置，用于tls配置，一般情况下用不到。它默认是nil，和当前的状态是兼容的。

I want to configure the CipherSuites and MinVersion about tls through this configuration.
我想通过这个配置，来配置tls的加密算法和最小版本。
