### PR TITLE
feat: httplib add WithContext()

### DIFF
--- a/client/httplib/httplib.go
+++ b/client/httplib/httplib.go
@@ -87,6 +87,7 @@ func NewBeegoRequest(rawurl, method string) *BeegoHTTPRequest {
 		files:   map[string]string{},
 		setting: defaultSetting,
 		resp:    &resp,
+		context: context.Background(),
 	}
 }
 
@@ -124,6 +125,18 @@ type BeegoHTTPRequest struct {
 	setting BeegoHTTPSettings
 	resp    *http.Response
 	body    []byte
+	context context.Context
+}
+
+// WithContext sets the context of BeegoHTTPRequest
+func (b *BeegoHTTPRequest) WithContext(ctx context.Context) *BeegoHTTPRequest {
+	b.context = ctx
+	return b
+}
+
+// Context gets the context of BeegoHTTPRequest
+func (b *BeegoHTTPRequest) Context() context.Context {
+	return b.context
 }
 
 // GetRequest returns the request object
@@ -445,7 +458,7 @@ func (b *BeegoHTTPRequest) getResponse() (*http.Response, error) {
 
 // DoRequest executes client.Do
 func (b *BeegoHTTPRequest) DoRequest() (resp *http.Response, err error) {
-	return b.DoRequestWithCtx(context.Background())
+	return b.DoRequestWithCtx(b.context)
 }
 
 func (b *BeegoHTTPRequest) DoRequestWithCtx(ctx context.Context) (resp *http.Response, err error) {

--- a/client/httplib/httplib_test.go
+++ b/client/httplib/httplib_test.go
@@ -446,3 +446,21 @@ func TestBeegoHTTPRequestJSONMarshal(t *testing.T) {
 	b, _ := req.JSONMarshal(body)
 	assert.Equal(t, fmt.Sprintf(`{"escape":"left&right"}%s`, "\n"), string(b))
 }
+
+func TestBeegoHTTPRequestWithContext(t *testing.T) {
+	// with set context
+	req := Post("http://beego.vip")
+
+	key := "foo"
+	ctx := context.WithValue(context.Background(), key, "bar")
+	req.WithContext(ctx)
+
+	assert.Equal(t, req.Context().Value(key).(string), "bar")
+	assert.NotNil(t, req.Context())
+
+	// without context
+	req = Post("http://beego.vip")
+
+	assert.Equal(t, req.Context(), context.Background())
+	assert.NotNil(t, req.Context())
+}


### PR DESCRIPTION
Support users to give customized context when using builder pattern.
Like: 
```
httplib.Get("your_url").WithContext(your_context).ToJson(&result)
```

But now we can only use like following:

```
req := httplib.Get("your_url")
resp, err := req.DoRequestWithCtx(c.Request().Context())

if err != nil {
    return err
}

defer resp.Body.Close()

// read from resp.Body
body, _ := ioutil.ReadAll(resp.Body)

// and then unmarshal json

json.Unmarshal(body, &result)

```