### PR TITLE
[bugfix] fix orm generate sql err on postgres

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - [Add httplib OpenTelemetry Filter](https://github.com/beego/beego/pull/4888, https://github.com/beego/beego/pull/4915)
 - [Support NewBeegoRequestWithCtx in httplib](https://github.com/beego/beego/pull/4895)
 - [Support lifecycle callback](https://github.com/beego/beego/pull/4918)
+- [fix orm bugs on postgres](https://github.com/beego/beego/pull/4933)
 
 # v2.0.2
 See v2.0.2-beta.1

--- a/client/orm/models.go
+++ b/client/orm/models.go
@@ -478,12 +478,10 @@ func (mc *_modelCache) getDbCreateSQL(al *alias) (queries []string, tableIndexes
 			if fi.description != "" {
 				switch al.Driver {
 				case DRPostgres:
-					// PostgreSQL comments
+					// postgres comments
 					sqlComments = append(sqlComments, fmt.Sprintf("COMMENT ON COLUMN %s.%s IS '%s';\n", mi.table,
 						fi.column, fi.description))
-					break
 				case DRSqlite:
-					break
 				default:
 					column += " " + fmt.Sprintf("COMMENT '%s'", fi.description)
 				}


### PR DESCRIPTION
postgres comment syntax like this
```sql
-- --------------------------------------------------
--  Table Structure for `train/internal/model.Test`
-- --------------------------------------------------
CREATE TABLE IF NOT EXISTS "test" (
    "id" serial NOT NULL PRIMARY KEY
);
COMMENT ON COLUMN test.id is 'record id';
```
so make a string array to cache field comments and append to the end of raw sql 