### PR TITLE
logs: multiFileLogWriter uses incorrect formatter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - [Add httplib OpenTelemetry Filter](https://github.com/beego/beego/pull/4888, https://github.com/beego/beego/pull/4915)
 - [Support NewBeegoRequestWithCtx in httplib](https://github.com/beego/beego/pull/4895)
 - [Support lifecycle callback](https://github.com/beego/beego/pull/4918)
+- [logs: multiFileLogWriter uses incorrect formatter](https://github.com/beego/beego/pull/4943)
 
 # v2.0.2
 See v2.0.2-beta.1

--- a/core/logs/multifile.go
+++ b/core/logs/multifile.go
@@ -83,12 +83,12 @@ func (f *multiFileLogWriter) Init(config string) error {
 	return nil
 }
 
-func (f *multiFileLogWriter) Format(lm *LogMsg) string {
+func (*multiFileLogWriter) Format(lm *LogMsg) string {
 	return lm.OldStyleFormat()
 }
 
 func (f *multiFileLogWriter) SetFormatter(fmt LogFormatter) {
-	f.fullLogWriter.SetFormatter(f)
+	f.fullLogWriter.SetFormatter(fmt)
 }
 
 func (f *multiFileLogWriter) Destroy() {


### PR DESCRIPTION
Closes #4912 