### PR TITLE
Update tree.go

### DIFF
--- a/server/web/tree.go
+++ b/server/web/tree.go
@@ -341,7 +341,8 @@ func (t *Tree) match(treePattern string, pattern string, wildcardValues []string
 	if runObject == nil && len(t.fixrouters) > 0 {
 		// Filter the .json .xml .html extension
 		for _, str := range allowSuffixExt {
-			if strings.HasSuffix(seg, str) && strings.HasSuffix(treePattern, seg) {
+			//pattern == "" avoid cases: /aaa.html/aaa.html could access /aaa/:bbb
+			if strings.HasSuffix(seg, str) && pattern == "" {
 				for _, subTree := range t.fixrouters {
 					// strings.HasSuffix(treePattern, seg) avoid cases: /aaa.html/bbb could access /aaa/bbb
 					if subTree.prefix == seg[:len(seg)-len(str)] {


### PR DESCRIPTION
fix issues "https://github.com/beego/beego/issues/4946"
when `pattern == "" ` , it means ` seg ` is the last element，so we can treat aa.xml as aa , and set `:ext` as `xml`.