### PR TITLE
Fix: Graceful mode can't running in http

### DIFF
--- a/server/web/server.go
+++ b/server/web/server.go
@@ -215,17 +215,11 @@ func (app *HttpServer) Run(addr string, mws ...MiddleWare) {
 				if app.Cfg.Listen.ListenTCP4 {
 					server.Network = "tcp4"
 				}
-				ln, err := net.Listen(server.Network, app.Server.Addr)
-				if err != nil {
-					logs.Critical("Listen for HTTP[graceful mode]: ", err)
-					endRunning <- true
-					return
-				}
 				for _, callback := range app.LifeCycleCallbacks {
 					callback.AfterStart(app)
 				}
-				if err := server.ServeWithListener(ln); err != nil {
-					logs.Critical("ServeWithListener: ", err, fmt.Sprintf("%d", os.Getpid()))
+				if err := server.ListenAndServe(); err != nil {
+					logs.Critical("ListenAndServe: ", err, fmt.Sprintf("%d", os.Getpid()))
 					time.Sleep(100 * time.Microsecond)
 				}
 				endRunning <- true


### PR DESCRIPTION
We don't need ServeWithListener to start server. use `ListenAndServe` is better choice, they do same things. and it can fix issue that http server be blocked in graceful mode.