### PR TITLE
fix: cache random time offset expired.

### DIFF
--- a/client/cache/cache_test.go
+++ b/client/cache/cache_test.go
@@ -219,3 +219,25 @@ func testDecrOverFlow(t *testing.T, c Cache, timeout time.Duration) {
 		return
 	}
 }
+
+func TestRandomExpireCache(t *testing.T) {
+
+	bm, err := NewCache("memory", `{"interval":20}`)
+	assert.Nil(t, err)
+
+	cache := NewRandomExpireCache(bm)
+
+	timeoutDuration := 5 * time.Second
+
+	if err = cache.Put(context.Background(), "Leon Ding", 22, timeoutDuration); err != nil {
+		t.Error("set Error", err)
+	}
+
+	if res, _ := bm.IsExist(context.Background(), "Leon Ding"); !res {
+		t.Error("check err")
+	}
+
+	if v, _ := bm.Get(context.Background(), "Leon Ding"); v.(int) != 22 {
+		t.Error("get err")
+	}
+}

--- a/client/cache/cache_test.go
+++ b/client/cache/cache_test.go
@@ -225,9 +225,9 @@ func TestRandomExpireCache(t *testing.T) {
 	bm, err := NewCache("memory", `{"interval":20}`)
 	assert.Nil(t, err)
 
-	cache := NewRandomExpireCache(bm)
+	cache := NewRandomExpireCache(bm, DefaultExpiredOffs)
 
-	timeoutDuration := 5 * time.Second
+	timeoutDuration := 3 * time.Second
 
 	if err = cache.Put(context.Background(), "Leon Ding", 22, timeoutDuration); err != nil {
 		t.Error("set Error", err)

--- a/client/cache/cache_test.go
+++ b/client/cache/cache_test.go
@@ -219,25 +219,3 @@ func testDecrOverFlow(t *testing.T, c Cache, timeout time.Duration) {
 		return
 	}
 }
-
-func TestRandomExpireCache(t *testing.T) {
-
-	bm, err := NewCache("memory", `{"interval":20}`)
-	assert.Nil(t, err)
-
-	cache := NewRandomExpireCache(bm, DefaultExpiredFunc)
-
-	timeoutDuration := 3 * time.Second
-
-	if err = cache.Put(context.Background(), "Leon Ding", 22, timeoutDuration); err != nil {
-		t.Error("set Error", err)
-	}
-
-	if res, _ := bm.IsExist(context.Background(), "Leon Ding"); !res {
-		t.Error("check err")
-	}
-
-	if v, _ := bm.Get(context.Background(), "Leon Ding"); v.(int) != 22 {
-		t.Error("get err")
-	}
-}

--- a/client/cache/cache_test.go
+++ b/client/cache/cache_test.go
@@ -225,7 +225,7 @@ func TestRandomExpireCache(t *testing.T) {
 	bm, err := NewCache("memory", `{"interval":20}`)
 	assert.Nil(t, err)
 
-	cache := NewRandomExpireCache(bm, DefaultExpiredOffs)
+	cache := NewRandomExpireCache(bm, DefaultExpiredFunc)
 
 	timeoutDuration := 3 * time.Second
 

--- a/client/cache/random_expired_cache.go
+++ b/client/cache/random_expired_cache.go
@@ -32,11 +32,7 @@ type RandomExpireCache struct {
 
 // Put random time offset expired
 func (rec *RandomExpireCache) Put(ctx context.Context, key string, val interface{}, timeout time.Duration) error {
-<<<<<<< HEAD
 	timeout += rec.offset()
-=======
-	timeout = generate(timeout, rec.offset)
->>>>>>> f435842a836c9fd832651f2502b32a75bd9e520f
 	return rec.cache.Put(ctx, key, val, timeout)
 }
 

--- a/client/cache/random_expired_cache.go
+++ b/client/cache/random_expired_cache.go
@@ -39,13 +39,9 @@ func (rec *RandomExpireCache) Put(ctx context.Context, key string, val interface
 // NewRandomExpireCache return random expire cache struct
 func NewRandomExpireCache(adapter Cache, opts ...RandomExpireCacheOption) Cache {
 	var cache RandomExpireCache
-	if len(opts) > 0 {
-		for _, fn := range opts {
-			fn(&cache)
-		}
-	}
-	if cache.Offset == nil {
-		cache.Offset = defaultExpiredFunc
+	cache.Offset = defaultExpiredFunc
+	for _, fn := range opts {
+		fn(&cache)
 	}
 	cache.cache = adapter
 	return &cache
@@ -53,13 +49,7 @@ func NewRandomExpireCache(adapter Cache, opts ...RandomExpireCacheOption) Cache 
 
 // defaultExpiredFunc genreate random time offset expired
 func defaultExpiredFunc() time.Duration {
-	offs := (time.Duration(rand.Intn(5)) * time.Second)
-
-	for (offs < offs+(2*time.Second)) && (offs > offs+(8*time.Second)) {
-		offs = (time.Duration(rand.Intn(5)) * time.Second)
-	}
-
-	return offs
+	return time.Duration(rand.Intn(5)+3) * time.Second
 }
 
 // Get get value from memcache.

--- a/client/cache/random_expired_cache.go
+++ b/client/cache/random_expired_cache.go
@@ -36,7 +36,7 @@ func (rec *RandomExpireCache) Put(ctx context.Context, key string, val interface
 	return rec.cache.Put(ctx, key, val, timeout)
 }
 
-// NewRandomExpireCache
+// NewRandomExpireCache return random expire cache struct
 func NewRandomExpireCache(adapter Cache, generate ExpiredFunc) Cache {
 	return &RandomExpireCache{
 		cache:  adapter,
@@ -44,7 +44,7 @@ func NewRandomExpireCache(adapter Cache, generate ExpiredFunc) Cache {
 	}
 }
 
-// DefaultExpiredFunc random time offset expired
+// DefaultExpiredFunc genreate random time offset expired
 func DefaultExpiredFunc() time.Duration {
 
 	rand.Seed(time.Now().UnixNano())

--- a/client/cache/random_expired_cache.go
+++ b/client/cache/random_expired_cache.go
@@ -1,0 +1,93 @@
+// Copyright 2014 beego Author. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cache
+
+import (
+	"context"
+	"math/rand"
+	"time"
+)
+
+// RandomExpireCache prevent cache batch invalidation
+// Cache random time offset expired
+type RandomExpireCache struct {
+	cache  Cache
+	offset int
+}
+
+// Put random time offset expired
+func (rec *RandomExpireCache) Put(ctx context.Context, key string, val interface{}, timeout time.Duration) error {
+	timeout += generate(timeout, rec.offset)
+	return rec.cache.Put(ctx, key, val, timeout)
+}
+
+// NewRandomExpireCache
+func NewRandomExpireCache(adapter Cache) Cache {
+	return &RandomExpireCache{
+		cache:  adapter,
+		offset: 8,
+	}
+}
+
+func generate(timeout time.Duration, offset int) time.Duration {
+	rand.Seed(time.Now().UnixNano())
+	timeout += (time.Duration(rand.Intn(offset)) * time.Second)
+	for timeout <= timeout+(2*time.Second) && timeout >= timeout+(8*time.Second) {
+		timeout += (time.Duration(rand.Intn(offset)) * time.Second)
+	}
+	return timeout
+}
+
+// Get get value from memcache.
+func (rec *RandomExpireCache) Get(ctx context.Context, key string) (interface{}, error) {
+	return rec.Get(ctx, key)
+}
+
+// GetMulti gets a value from a key in memcache.
+func (rec *RandomExpireCache) GetMulti(ctx context.Context, keys []string) ([]interface{}, error) {
+	return rec.cache.GetMulti(ctx, keys)
+}
+
+// Delete deletes a value in memcache.
+func (rec *RandomExpireCache) Delete(ctx context.Context, key string) error {
+	return rec.cache.Delete(ctx, key)
+}
+
+// Incr increases counter.
+func (rec *RandomExpireCache) Incr(ctx context.Context, key string) error {
+	return rec.cache.Incr(ctx, key)
+}
+
+// Decr decreases counter.
+func (rec *RandomExpireCache) Decr(ctx context.Context, key string) error {
+	return rec.cache.Decr(ctx, key)
+}
+
+// IsExist checks if a value exists in memcache.
+func (rec *RandomExpireCache) IsExist(ctx context.Context, key string) (bool, error) {
+	return rec.cache.IsExist(ctx, key)
+}
+
+// ClearAll clears all cache in memcache.
+func (rec *RandomExpireCache) ClearAll(ctx context.Context) error {
+	return rec.cache.ClearAll(ctx)
+}
+
+// StartAndGC starts the memcache adapter.
+// config: must be in the format {"conn":"connection info"}.
+// If an error occurs during connecting, an error is returned
+func (rec *RandomExpireCache) StartAndGC(config string) error {
+	return rec.cache.StartAndGC(config)
+}

--- a/client/cache/random_expired_cache.go
+++ b/client/cache/random_expired_cache.go
@@ -21,7 +21,7 @@ import (
 )
 
 // ExpiredFunc implement genreate random time offset expired
-type RandomExpireCacheOptions func(*RandomExpireCache)
+type RandomExpireCacheOption func(*RandomExpireCache)
 
 // RandomExpireCache prevent cache batch invalidation
 // Cache random time offset expired
@@ -37,7 +37,7 @@ func (rec *RandomExpireCache) Put(ctx context.Context, key string, val interface
 }
 
 // NewRandomExpireCache return random expire cache struct
-func NewRandomExpireCache(adapter Cache, opts ...RandomExpireCacheOptions) Cache {
+func NewRandomExpireCache(adapter Cache, opts ...RandomExpireCacheOption) Cache {
 	var cache RandomExpireCache
 	if len(opts) > 0 {
 		for _, fn := range opts {

--- a/client/cache/random_expired_cache_test.go
+++ b/client/cache/random_expired_cache_test.go
@@ -28,7 +28,7 @@ func TestRandomExpireCache(t *testing.T) {
 	assert.Nil(t, err)
 
 	// cache := NewRandomExpireCache(bm)
-	cache := NewRandomExpireCache(bm, func(opt *RandomExpireCacheOptions) {
+	cache := NewRandomExpireCache(bm, func(opt *RandomExpireCache) {
 		opt.Offset = defaultExpiredFunc
 	})
 

--- a/client/cache/random_expired_cache_test.go
+++ b/client/cache/random_expired_cache_test.go
@@ -1,0 +1,82 @@
+// Copyright 2014 beego Author. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cache
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRandomExpireCache(t *testing.T) {
+	bm, err := NewCache("memory", `{"interval":20}`)
+	assert.Nil(t, err)
+
+	cache := NewRandomExpireCache(bm, DefaultExpiredFunc)
+
+	timeoutDuration := 3 * time.Second
+
+	if err = cache.Put(context.Background(), "Leon Ding", 22, timeoutDuration); err != nil {
+		t.Error("set Error", err)
+	}
+
+	if res, _ := cache.IsExist(context.Background(), "Leon Ding"); !res {
+		t.Error("check err")
+	}
+
+	if v, _ := cache.Get(context.Background(), "Leon Ding"); v.(int) != 22 {
+		t.Error("get err")
+	}
+
+	cache.Delete(context.Background(), "Leon Ding")
+	res, _ := cache.IsExist(context.Background(), "Leon Ding")
+	assert.False(t, res)
+
+	assert.Nil(t, cache.Put(context.Background(), "Leon Ding", "author", timeoutDuration))
+
+	cache.Delete(context.Background(), "astaxie")
+	res, _ = cache.IsExist(context.Background(), "astaxie")
+	assert.False(t, res)
+
+	assert.Nil(t, cache.Put(context.Background(), "astaxie", "author", timeoutDuration))
+
+	res, _ = cache.IsExist(context.Background(), "astaxie")
+	assert.True(t, res)
+
+	v, _ := cache.Get(context.Background(), "astaxie")
+	assert.Equal(t, "author", v)
+
+	assert.Nil(t, cache.Put(context.Background(), "astaxie1", "author1", timeoutDuration))
+
+	res, _ = cache.IsExist(context.Background(), "astaxie1")
+	assert.True(t, res)
+
+	vv, _ := cache.GetMulti(context.Background(), []string{"astaxie", "astaxie1"})
+	assert.Equal(t, 2, len(vv))
+	assert.Equal(t, "author", vv[0])
+	assert.Equal(t, "author1", vv[1])
+
+	vv, err = cache.GetMulti(context.Background(), []string{"astaxie0", "astaxie1"})
+	assert.Equal(t, 2, len(vv))
+	assert.Nil(t, vv[0])
+	assert.Equal(t, "author1", vv[1])
+
+	assert.NotNil(t, err)
+	assert.True(t, strings.Contains(err.Error(), "key isn't exist"))
+
+}

--- a/client/cache/random_expired_cache_test.go
+++ b/client/cache/random_expired_cache_test.go
@@ -27,7 +27,10 @@ func TestRandomExpireCache(t *testing.T) {
 	bm, err := NewCache("memory", `{"interval":20}`)
 	assert.Nil(t, err)
 
-	cache := NewRandomExpireCache(bm, DefaultExpiredFunc)
+	// cache := NewRandomExpireCache(bm)
+	cache := NewRandomExpireCache(bm, func(opt *RandomExpireCacheOptions) {
+		opt.Offset = defaultExpiredFunc
+	})
 
 	timeoutDuration := 3 * time.Second
 


### PR DESCRIPTION
1. fix: [https://github.com/beego/beego/issues/4966](https://github.com/beego/beego/issues/4966)
2. add a random offset to the expire time.