### PR TITLE
fix: nil offset function of RandomExpireCache instance

### DIFF
--- a/client/cache/random_expired_cache.go
+++ b/client/cache/random_expired_cache.go
@@ -27,12 +27,12 @@ type RandomExpireCacheOption func(*RandomExpireCache)
 // Cache random time offset expired
 type RandomExpireCache struct {
 	Cache
-	offset func() time.Duration
+	Offset func() time.Duration
 }
 
 // Put random time offset expired
 func (rec *RandomExpireCache) Put(ctx context.Context, key string, val interface{}, timeout time.Duration) error {
-	timeout += rec.offset()
+	timeout += rec.Offset()
 	return rec.Cache.Put(ctx, key, val, timeout)
 }
 
@@ -42,6 +42,9 @@ func NewRandomExpireCache(adapter Cache, opts ...RandomExpireCacheOption) Cache 
 	rec.Cache = adapter
 	for _, fn := range opts {
 		fn(&rec)
+	}
+	if rec.Offset == nil {
+		rec.Offset = defaultExpiredFunc
 	}
 	return &rec
 }

--- a/client/cache/random_expired_cache_test.go
+++ b/client/cache/random_expired_cache_test.go
@@ -29,7 +29,7 @@ func TestRandomExpireCache(t *testing.T) {
 
 	// cache := NewRandomExpireCache(bm)
 	cache := NewRandomExpireCache(bm, func(opt *RandomExpireCache) {
-		opt.offset = defaultExpiredFunc
+		opt.Offset = defaultExpiredFunc()
 	})
 
 	timeoutDuration := 3 * time.Second


### PR DESCRIPTION
1. when creating an RandomExpireCache instance, use the default random time generation function and allow external definitions
2. avoid using global rand instances to improve concurrency performance