### PR TITLE
fix pass []any as any in variadic function by asasalint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 - [Fix 4984: random expire cache](https://github.com/beego/beego/pull/4984)
 - [Fix 4907: make admin serve HTTP only](https://github.com/beego/beego/pull/5005)
 - [Feat 4999: add get all tasks function](https://github.com/beego/beego/pull/4999)
+- [Fix 5012: fix some bug, pass []any as any in variadic function](https://github.com/beego/beego/pull/5012)
 
 
 # v2.0.4

--- a/adapter/app.go
+++ b/adapter/app.go
@@ -245,7 +245,7 @@ func Any(rootpath string, f FilterFunc) *App {
 //          fmt.Fprintf(w, "Hello, %q", html.EscapeString(r.URL.Path))
 //    }))
 func Handler(rootpath string, h http.Handler, options ...interface{}) *App {
-	return (*App)(web.Handler(rootpath, h, options))
+	return (*App)(web.Handler(rootpath, h, options...))
 }
 
 // InsertFilter adds a FilterFunc with pattern condition and action constant.

--- a/adapter/context/context.go
+++ b/adapter/context/context.go
@@ -78,7 +78,7 @@ func (ctx *Context) GetCookie(key string) string {
 // SetCookie Set cookie for response.
 // It's alias of BeegoOutput.Cookie.
 func (ctx *Context) SetCookie(name string, value string, others ...interface{}) {
-	(*context.Context)(ctx).SetCookie(name, value, others)
+	(*context.Context)(ctx).SetCookie(name, value, others...)
 }
 
 // GetSecureCookie Get secure cookie from request by a given key.
@@ -88,7 +88,7 @@ func (ctx *Context) GetSecureCookie(Secret, key string) (string, bool) {
 
 // SetSecureCookie Set Secure cookie for response.
 func (ctx *Context) SetSecureCookie(Secret, name, value string, others ...interface{}) {
-	(*context.Context)(ctx).SetSecureCookie(Secret, name, value, others)
+	(*context.Context)(ctx).SetSecureCookie(Secret, name, value, others...)
 }
 
 // XSRFToken creates a xsrf token string and returns.

--- a/adapter/context/output.go
+++ b/adapter/context/output.go
@@ -47,7 +47,7 @@ func (output *BeegoOutput) Body(content []byte) error {
 // Cookie sets cookie value via given key.
 // others are ordered as cookie's max age time, path,domain, secure and httponly.
 func (output *BeegoOutput) Cookie(name string, value string, others ...interface{}) {
-	(*context.BeegoOutput)(output).Cookie(name, value, others)
+	(*context.BeegoOutput)(output).Cookie(name, value, others...)
 }
 
 // JSON writes json to response body.

--- a/adapter/orm/db_alias.go
+++ b/adapter/orm/db_alias.go
@@ -69,7 +69,7 @@ func (d *DB) QueryContext(ctx context.Context, query string, args ...interface{}
 }
 
 func (d *DB) QueryRow(query string, args ...interface{}) *sql.Row {
-	return (*orm.DB)(d).QueryRow(query, args)
+	return (*orm.DB)(d).QueryRow(query, args...)
 }
 
 func (d *DB) QueryRowContext(ctx context.Context, query string, args ...interface{}) *sql.Row {

--- a/adapter/router.go
+++ b/adapter/router.go
@@ -212,7 +212,7 @@ func (p *ControllerRegister) AddMethod(method, pattern string, f FilterFunc) {
 
 // Handler add user defined Handler
 func (p *ControllerRegister) Handler(pattern string, h http.Handler, options ...interface{}) {
-	(*web.ControllerRegister)(p).Handler(pattern, h, options)
+	(*web.ControllerRegister)(p).Handler(pattern, h, options...)
 }
 
 // AddAuto router to ControllerRegister.


### PR DESCRIPTION
i'm write a [linter](https://github.com/alingse/asasalint) about check pass `[]any` as `any` in variadic functions

I search the top go repo,  run the check,  and found this one failed in github actions

see https://github.com/alingse/asasalint/runs/7262743178

there is  10 func call found. 
```
Error: /home/runner/work/asasalint/asasalint/beego/adapter/context/context.go:81:49: pass []any as any to func SetCookie func(name string, value string, others ...interface{})
Error: /home/runner/work/asasalint/asasalint/beego/adapter/context/context.go:91:63: pass []any as any to func SetSecureCookie func(Secret string, name string, value string, others ...interface{})
Error: /home/runner/work/asasalint/asasalint/beego/adapter/context/output.go:[5](https://github.com/alingse/asasalint/runs/7262743178?check_suite_focus=true#step:7:6)0:53: pass []any as any to func Cookie func(name string, value string, others ...interface{})
Error: /home/runner/work/asasalint/asasalint/beego/adapter/app.go:248:41: pass []any as any to func Handler func(rootpath string, h net/http.Handler, options ...interface{}) *github.com/beego/beego/v2/server/web.HttpServer
Error: /home/runner/work/asasalint/asasalint/beego/adapter/router.go:215:51: pass []any as any to func Handler func(pattern string, h net/http.Handler, options ...interface{})
Error: /home/runner/work/asasalint/asasalint/beego/client/orm/orm_querym2m.go:118:[6](https://github.com/alingse/asasalint/runs/7262743178?check_suite_focus=true#step:7:7)1: pass []any as any to func Filter func(string, ...interface{}) github.com/beego/beego/v2/client/orm.QuerySeter
Error: /home/runner/work/asasalint/asasalint/beego/adapter/orm/db_alias.go:[7](https://github.com/alingse/asasalint/runs/7262743178?check_suite_focus=true#step:7:8)2:38: pass []any as any to func QueryRow func(query string, args ...interface{}) *database/sql.Row
Error: /home/runner/work/asasalint/asasalint/beego/client/orm/orm_test.go:1621:21: pass []any as any to func Add func(...interface{}) (int64, error)
Error: /home/runner/work/asasalint/asasalint/beego/client/orm/orm_test.go:1629:24: pass []any as any to func Remove func(...interface{}) (int64, error)
Error: /home/runner/work/asasalint/asasalint/beego/client/orm/orm_test.go:16[8](https://github.com/alingse/asasalint/runs/7262743178?check_suite_focus=true#step:7:9)6:21: pass []any as any to func Add func(...interface{}) (int64, error)
Error: /home/runner/work/asasalint/asasalint/beego/client/orm/orm_test.go:16[9](https://github.com/alingse/asasalint/runs/7262743178?check_suite_focus=true#step:7:10)4:24: pass []any as any to func Remove func(...interface{}) (int64, error)
```

the  `context`, `web` part seems like a mistake, but the `orm` part in `orm_test.go` / `db_alias.go` might was by design.

so I only fix the first part.


