### PR TITLE
multiple order by with asc and desc not working bug fixed

### DIFF
--- a/client/orm/qb_mysql.go
+++ b/client/orm/qb_mysql.go
@@ -25,7 +25,8 @@ const CommaSpace = ", "
 
 // MySQLQueryBuilder is the SQL build
 type MySQLQueryBuilder struct {
-	tokens []string
+	tokens       []string
+	orderByAdded bool
 }
 
 // Select will join the fields
@@ -96,6 +97,14 @@ func (qb *MySQLQueryBuilder) In(vals ...string) QueryBuilder {
 
 // OrderBy join the Order by fields
 func (qb *MySQLQueryBuilder) OrderBy(fields ...string) QueryBuilder {
+
+	if qb.orderByAdded {
+		qb.tokens = append(qb.tokens, CommaSpace, strings.Join(fields, CommaSpace))
+		return qb
+	}
+
+	qb.orderByAdded = true
+
 	qb.tokens = append(qb.tokens, "ORDER BY", strings.Join(fields, CommaSpace))
 	return qb
 }

--- a/client/orm/qb_postgres.go
+++ b/client/orm/qb_postgres.go
@@ -10,7 +10,8 @@ var quote string = `"`
 
 // PostgresQueryBuilder is the SQL build
 type PostgresQueryBuilder struct {
-	tokens []string
+	tokens       []string
+	orderByAdded bool
 }
 
 func processingStr(str []string) string {
@@ -124,6 +125,14 @@ func (qb *PostgresQueryBuilder) In(vals ...string) QueryBuilder {
 // OrderBy join the Order by fields
 func (qb *PostgresQueryBuilder) OrderBy(fields ...string) QueryBuilder {
 	str := processingStr(fields)
+
+	if qb.orderByAdded {
+		qb.tokens = append(qb.tokens, CommaSpace, str)
+		return qb
+	}
+
+	qb.orderByAdded = true
+
 	qb.tokens = append(qb.tokens, "ORDER BY", str)
 	return qb
 }


### PR DESCRIPTION
Currently following code does not work in query builder.

`Select("id", "name"),From("articles").OrderBy("id").Desc().OrderBy("like_count").Asc().String()`

because it makes following query

`select id, name from articles order by id desc order by like_count asc`

so i made changes to fix this, now after the changes it will create following query 

`select id, name from articles order by id desc, like_count asc`