### PR TITLE
Add:Get response with media type

### DIFF
--- a/client/httplib/filter.go
+++ b/client/httplib/filter.go
@@ -21,4 +21,8 @@ import (
 
 type FilterChain func(next Filter) Filter
 
+type FilterChainWithMedia func(next FilterWithMedia) FilterWithMedia
+
 type Filter func(ctx context.Context, req *BeegoHTTPRequest) (*http.Response, error)
+
+type FilterWithMedia func(ctx context.Context, media string, req *BeegoHTTPRequest) (*http.Response, error)

--- a/client/httplib/setting.go
+++ b/client/httplib/setting.go
@@ -25,19 +25,20 @@ import (
 
 // BeegoHTTPSettings is the http.Client setting
 type BeegoHTTPSettings struct {
-	UserAgent        string
-	ConnectTimeout   time.Duration
-	ReadWriteTimeout time.Duration
-	TLSClientConfig  *tls.Config
-	Proxy            func(*http.Request) (*url.URL, error)
-	Transport        http.RoundTripper
-	CheckRedirect    func(req *http.Request, via []*http.Request) error
-	EnableCookie     bool
-	Gzip             bool
-	Retries          int // if set to -1 means will retry forever
-	RetryDelay       time.Duration
-	FilterChains     []FilterChain
-	EscapeHTML       bool // if set to false means will not escape escape HTML special characters during processing, default true
+	UserAgent             string
+	ConnectTimeout        time.Duration
+	ReadWriteTimeout      time.Duration
+	TLSClientConfig       *tls.Config
+	Proxy                 func(*http.Request) (*url.URL, error)
+	Transport             http.RoundTripper
+	CheckRedirect         func(req *http.Request, via []*http.Request) error
+	EnableCookie          bool
+	Gzip                  bool
+	Retries               int // if set to -1 means will retry forever
+	RetryDelay            time.Duration
+	FilterChains          []FilterChain
+	FilterWithMediaChains []FilterChainWithMedia
+	EscapeHTML            bool // if set to false means will not escape escape HTML special characters during processing, default true
 }
 
 // createDefaultCookie creates a global cookiejar to store cookies.


### PR DESCRIPTION
In my work, there is a business situation: the client needs content-type in the server's return to be in other formats by setting the content-type of the request header to the json format. So I want to add a http request method that allows the client to specify the content-type of the return body while sending the request.