### PR TITLE
Provision to reset database cache

### DIFF
--- a/orm/db_alias.go
+++ b/orm/db_alias.go
@@ -467,3 +467,7 @@ func newStmtDecoratorLruWithEvict() *lru.Cache {
 	})
 	return cache
 }
+
+func ResetDataBaseCache() {
+	dataBaseCache = &_dbCache{cache: make(map[string]*alias)}
+}


### PR DESCRIPTION
**Reason to Update:**
I am trying to write UT for DB connections by mocking db using github.com/DATA-DOG/go-sqlmock. I want to recreate mock db and set to orm just before execution each test case. However the current implementation of orm.AddAliasWthDB is not allowing to reset db driver once it is initialized. It will throw the error fmt.Errorf("DataBase alias name %s already registered, cannot reuse", aliasName)