### PR TITLE
Migration中 增加方法 DropTable

### DIFF
--- a/client/orm/migration/ddl.go
+++ b/client/orm/migration/ddl.go
@@ -396,7 +396,7 @@ func (m *Migration) GetSQL() (sql string) {
 
 			for index, ind := range m.Indexes {
 				sql += fmt.Sprintf("\n DROP KEY `%s`", ind.Name)
-				if len(m.Uniques) > index+1 {
+				if len(m.Indexes) > index+1 {
 					sql += ","
 				}
 

--- a/client/orm/migration/ddl.go
+++ b/client/orm/migration/ddl.go
@@ -321,7 +321,7 @@ func (m *Migration) GetSQL() (sql string) {
 						sql += ","
 					}
 				}
-				sql += fmt.Sprintf(")")
+				sql += ")"
 			}
 
 			for _, foreign := range m.Foreigns {

--- a/client/orm/migration/ddl.go
+++ b/client/orm/migration/ddl.go
@@ -77,6 +77,12 @@ func (m *Migration) AlterTable(tablename string) {
 	m.ModifyType = "alter"
 }
 
+// DropTable set the ModifyType to drop
+func (m *Migration) DropTable(tablename string) {
+	m.TableName = tablename
+	m.ModifyType = "delete"
+}
+
 // NewCol creates a new standard column and attaches it to m struct
 func (m *Migration) NewCol(name string) *Column {
 	col := &Column{Name: name}


### PR DESCRIPTION
在migration中，没有找到关于DropTable的方法，使得在数据迁移时，只能使用sql语句进行删除Table。现增加这个方法DropTable用于删除Table