### PR TITLE
chore: fmt modify

### DIFF
--- a/core/config/json/json.go
+++ b/core/config/json/json.go
@@ -99,12 +99,12 @@ func (c *JSONConfigContainer) sub(key string) (map[string]interface{}, error) {
 	}
 	value, ok := c.data[key]
 	if !ok {
-		return nil, errors.New(fmt.Sprintf("key is not found: %s", key))
+		return nil, fmt.Errorf("key is not found: %s", key)
 	}
 
 	res, ok := value.(map[string]interface{})
 	if !ok {
-		return nil, errors.New(fmt.Sprintf("the type of value is invalid, key: %s", key))
+		return nil, fmt.Errorf("the type of value is invalid, key: %s", key)
 	}
 	return res, nil
 }

--- a/core/config/xml/xml.go
+++ b/core/config/xml/xml.go
@@ -120,11 +120,11 @@ func (c *ConfigContainer) sub(key string) (map[string]interface{}, error) {
 	}
 	value, ok := c.data[key]
 	if !ok {
-		return nil, errors.New(fmt.Sprintf("the key is not found: %s", key))
+		return nil, fmt.Errorf("the key is not found: %s", key)
 	}
 	res, ok := value.(map[string]interface{})
 	if !ok {
-		return nil, errors.New(fmt.Sprintf("the value of this key is not a structure: %s", key))
+		return nil, fmt.Errorf("the value of this key is not a structure: %s", key)
 	}
 	return res, nil
 }

--- a/core/logs/es/es.go
+++ b/core/logs/es/es.go
@@ -81,7 +81,7 @@ func (el *esLogger) Init(config string) error {
 	if len(el.Formatter) > 0 {
 		fmtr, ok := logs.GetFormatter(el.Formatter)
 		if !ok {
-			return errors.New(fmt.Sprintf("the formatter with name: %s not found", el.Formatter))
+			return fmt.Errorf("the formatter with name: %s not found", el.Formatter)
 		}
 		el.formatter = fmtr
 	}

--- a/server/web/config.go
+++ b/server/web/config.go
@@ -505,7 +505,7 @@ func defaultRecoverPanic(ctx *context.Context, cfg *Config) {
 				break
 			}
 			logs.Critical(fmt.Sprintf("%s:%d", file, line))
-			stack = stack + fmt.Sprintln(fmt.Sprintf("%s:%d", file, line))
+			stack = stack + fmt.Sprintf("%s:%d\n", file, line)
 		}
 
 		if ctx.Output.Status != 0 {
@@ -629,7 +629,7 @@ func assignConfig(ac config.Configer) error {
 	for adaptor, cfg := range BConfig.Log.Outputs {
 		err := logs.SetLogger(adaptor, cfg)
 		if err != nil {
-			fmt.Fprintln(os.Stderr, fmt.Sprintf("%s with the config %q got err:%s", adaptor, cfg, err.Error()))
+			fmt.Fprintf(os.Stderr, "%s with the config %q got err:%s\n", adaptor, cfg, err.Error())
 			return err
 		}
 	}

--- a/task/task_test.go
+++ b/task/task_test.go
@@ -147,7 +147,7 @@ func TestTask_Run(t *testing.T) {
 	task := func(ctx context.Context) error {
 		cnt++
 		fmt.Printf("Hello, world! %d \n", cnt)
-		return errors.New(fmt.Sprintf("Hello, world! %d", cnt))
+		return fmt.Errorf("Hello, world! %d", cnt)
 	}
 	tk := NewTask("taska", "0/30 * * * * *", task)
 	for i := 0; i < 200; i++ {


### PR DESCRIPTION
should use fmt.Errorf(...) instead of errors.New(fmt.Sprintf(...)) (S1028)
should use fmt.Sprintf instead of fmt.Sprintln(fmt.Sprintf(...)) (but don't forget the newline) (S1038)
should use fmt.Fprintf instead of fmt.Fprintln(fmt.Sprintf(...)) (but don't forget the newline) (S1038)