### PR TITLE
fix: Beego web.Run() runs the server twice

### DIFF
--- a/server/web/beego.go
+++ b/server/web/beego.go
@@ -50,8 +50,9 @@ func AddAPPStartHook(hf ...hookfunc) {
 func Run(params ...string) {
 	if len(params) > 0 && params[0] != "" {
 		BeeApp.Run(params[0])
+	} else {
+		BeeApp.Run("")
 	}
-	BeeApp.Run("")
 }
 
 // RunWithMiddleWares Run beego application with middlewares.


### PR DESCRIPTION
Beego's `web.Run()` runs the server twice, which is not intended I believe. This is the simple fix for that.