### PR TITLE
fix: use of ioutil package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - [feat: add write-delete cache mode](https://github.com/beego/beego/pull/5242)
 - [fix 5255: Check the rows.Err() if rows.Next() is false](https://github.com/beego/beego/pull/5256)
 - [orm: missing handling %COL% placeholder](https://github.com/beego/beego/pull/5257)
+- [fix: use of ioutil package](https://github.com/beego/beego/pull/5261)
 
 ## ORM refactoring
 - [introducing internal/models pkg](https://github.com/beego/beego/pull/5238)

--- a/client/cache/file.go
+++ b/client/cache/file.go
@@ -23,7 +23,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -307,7 +306,7 @@ func FileGetContents(filename string) ([]byte, error) {
 // FilePutContents puts bytes into a file.
 // if non-existent, create this file.
 func FilePutContents(filename string, content []byte) error {
-	return ioutil.WriteFile(filename, content, os.ModePerm)
+	return os.WriteFile(filename, content, os.ModePerm)
 }
 
 // GobEncode Gob encodes a file cache item.

--- a/client/cache/file.go
+++ b/client/cache/file.go
@@ -295,7 +295,7 @@ func exists(path string) (bool, error) {
 // FileGetContents Reads bytes from a file.
 // if non-existent, create this file.
 func FileGetContents(filename string) ([]byte, error) {
-	data, err := ioutil.ReadFile(filename)
+	data, err := os.ReadFile(filename)
 	if err != nil {
 		return nil, berror.Wrapf(err, ReadFileCacheContentFailed,
 			"could not read the data from the file: %s, "+

--- a/client/cache/write_delete.go
+++ b/client/cache/write_delete.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+
 	"github.com/beego/beego/v2/core/berror"
 )
 

--- a/client/cache/write_delete_test.go
+++ b/client/cache/write_delete_test.go
@@ -19,9 +19,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/stretchr/testify/assert"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
 
 	"github.com/beego/beego/v2/core/berror"
 )

--- a/client/httplib/http_response.go
+++ b/client/httplib/http_response.go
@@ -17,7 +17,7 @@ package httplib
 import (
 	"bytes"
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net/http"
 )
 
@@ -34,6 +34,6 @@ func NewHttpResponseWithJsonBody(data interface{}) *http.Response {
 	}
 	return &http.Response{
 		ContentLength: int64(len(body)),
-		Body:          ioutil.NopCloser(bytes.NewReader(body)),
+		Body:          io.NopCloser(bytes.NewReader(body)),
 	}
 }

--- a/client/httplib/httplib.go
+++ b/client/httplib/httplib.go
@@ -37,7 +37,6 @@ import (
 	"encoding/json"
 	"encoding/xml"
 	"io"
-	"io/ioutil"
 	"mime/multipart"
 	"net"
 	"net/http"
@@ -283,16 +282,16 @@ func (b *BeegoHTTPRequest) Body(data interface{}) *BeegoHTTPRequest {
 	switch t := data.(type) {
 	case string:
 		bf := bytes.NewBufferString(t)
-		b.req.Body = ioutil.NopCloser(bf)
+		b.req.Body = io.NopCloser(bf)
 		b.req.GetBody = func() (io.ReadCloser, error) {
-			return ioutil.NopCloser(bf), nil
+			return io.NopCloser(bf), nil
 		}
 		b.req.ContentLength = int64(len(t))
 	case []byte:
 		bf := bytes.NewBuffer(t)
-		b.req.Body = ioutil.NopCloser(bf)
+		b.req.Body = io.NopCloser(bf)
 		b.req.GetBody = func() (io.ReadCloser, error) {
-			return ioutil.NopCloser(bf), nil
+			return io.NopCloser(bf), nil
 		}
 		b.req.ContentLength = int64(len(t))
 	default:
@@ -308,9 +307,9 @@ func (b *BeegoHTTPRequest) XMLBody(obj interface{}) (*BeegoHTTPRequest, error) {
 		if err != nil {
 			return b, berror.Wrap(err, InvalidXMLBody, "obj could not be converted to XML data")
 		}
-		b.req.Body = ioutil.NopCloser(bytes.NewReader(byts))
+		b.req.Body = io.NopCloser(bytes.NewReader(byts))
 		b.req.GetBody = func() (io.ReadCloser, error) {
-			return ioutil.NopCloser(bytes.NewReader(byts)), nil
+			return io.NopCloser(bytes.NewReader(byts)), nil
 		}
 		b.req.ContentLength = int64(len(byts))
 		b.req.Header.Set(contentTypeKey, "application/xml")
@@ -325,7 +324,7 @@ func (b *BeegoHTTPRequest) YAMLBody(obj interface{}) (*BeegoHTTPRequest, error) 
 		if err != nil {
 			return b, berror.Wrap(err, InvalidYAMLBody, "obj could not be converted to YAML data")
 		}
-		b.req.Body = ioutil.NopCloser(bytes.NewReader(byts))
+		b.req.Body = io.NopCloser(bytes.NewReader(byts))
 		b.req.ContentLength = int64(len(byts))
 		b.req.Header.Set(contentTypeKey, "application/x+yaml")
 	}
@@ -339,7 +338,7 @@ func (b *BeegoHTTPRequest) JSONBody(obj interface{}) (*BeegoHTTPRequest, error) 
 		if err != nil {
 			return b, berror.Wrap(err, InvalidJSONBody, "obj could not be converted to JSON body")
 		}
-		b.req.Body = ioutil.NopCloser(bytes.NewReader(byts))
+		b.req.Body = io.NopCloser(bytes.NewReader(byts))
 		b.req.ContentLength = int64(len(byts))
 		b.req.Header.Set(contentTypeKey, "application/json")
 	}
@@ -400,7 +399,7 @@ func (b *BeegoHTTPRequest) handleFiles() {
 		_ = pw.Close()
 	}()
 	b.Header(contentTypeKey, bodyWriter.FormDataContentType())
-	b.req.Body = ioutil.NopCloser(pr)
+	b.req.Body = io.NopCloser(pr)
 	b.Header("Transfer-Encoding", "chunked")
 }
 

--- a/client/orm/cmd_utils_test.go
+++ b/client/orm/cmd_utils_test.go
@@ -1,9 +1,10 @@
 package orm
 
 import (
+	"testing"
+
 	"github.com/beego/beego/v2/client/orm/internal/models"
 	"github.com/stretchr/testify/assert"
-	"testing"
 )
 
 func Test_getColumnTyp(t *testing.T) {

--- a/client/orm/orm_test.go
+++ b/client/orm/orm_test.go
@@ -19,7 +19,6 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
-	"io/ioutil"
 	"math"
 	"os"
 	"path/filepath"
@@ -118,7 +117,7 @@ func getCaller(skip int) string {
 	pc, file, line, _ := runtime.Caller(skip)
 	fun := runtime.FuncForPC(pc)
 	_, fn := filepath.Split(file)
-	data, err := ioutil.ReadFile(file)
+	data, err := os.ReadFile(file)
 	var codes []string
 	if err == nil {
 		lines := bytes.Split(data, []byte{'\n'})

--- a/core/config/env/env.go
+++ b/core/config/env/env.go
@@ -19,7 +19,6 @@ package env
 import (
 	"fmt"
 	"go/build"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -119,7 +118,7 @@ func GetRuntimeEnv(key string) (string, error) {
 	}
 
 	var runtimeEnv string
-	data, err := ioutil.ReadFile(file)
+	data, err := os.ReadFile(file)
 	if err != nil {
 		return "", err
 	}

--- a/core/config/ini.go
+++ b/core/config/ini.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"errors"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/user"
 	"path/filepath"
@@ -54,7 +53,7 @@ func (ini *IniConfig) Parse(name string) (Configer, error) {
 }
 
 func (ini *IniConfig) parseFile(name string) (*IniConfigContainer, error) {
-	data, err := ioutil.ReadFile(name)
+	data, err := os.ReadFile(name)
 	if err != nil {
 		return nil, err
 	}

--- a/core/config/ini_test.go
+++ b/core/config/ini_test.go
@@ -16,7 +16,6 @@ package config
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strings"
 	"testing"
@@ -173,7 +172,7 @@ name=mysql
 	}
 	defer os.Remove(name)
 
-	if data, err := ioutil.ReadFile(name); err != nil {
+	if data, err := os.ReadFile(name); err != nil {
 		t.Fatal(err)
 	} else {
 		cfgData := string(data)

--- a/core/config/json/json.go
+++ b/core/config/json/json.go
@@ -18,7 +18,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"strconv"
 	"strings"
@@ -40,7 +40,7 @@ func (js *JSONConfig) Parse(filename string) (config.Configer, error) {
 		return nil, err
 	}
 	defer file.Close()
-	content, err := ioutil.ReadAll(file)
+	content, err := io.ReadAll(file)
 	if err != nil {
 		return nil, err
 	}

--- a/core/config/toml/toml.go
+++ b/core/config/toml/toml.go
@@ -15,7 +15,6 @@
 package toml
 
 import (
-	"io/ioutil"
 	"os"
 	"strings"
 
@@ -32,7 +31,7 @@ type Config struct {
 
 // Parse accepts filename as the parameter
 func (c *Config) Parse(filename string) (config.Configer, error) {
-	ctx, err := ioutil.ReadFile(filename)
+	ctx, err := os.ReadFile(filename)
 	if err != nil {
 		return nil, err
 	}

--- a/core/config/xml/xml.go
+++ b/core/config/xml/xml.go
@@ -32,7 +32,6 @@ import (
 	"encoding/xml"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strconv"
 	"strings"
@@ -53,7 +52,7 @@ type Config struct{}
 
 // Parse returns a ConfigContainer with parsed xml config map.
 func (xc *Config) Parse(filename string) (config.Configer, error) {
-	context, err := ioutil.ReadFile(filename)
+	context, err := os.ReadFile(filename)
 	if err != nil {
 		return nil, err
 	}

--- a/core/config/yaml/yaml.go
+++ b/core/config/yaml/yaml.go
@@ -26,7 +26,6 @@ package yaml
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strings"
 	"sync"
@@ -66,7 +65,7 @@ func (*Config) ParseData(data []byte) (config.Configer, error) {
 
 // ReadYmlReader Read yaml file to map.
 func ReadYmlReader(path string) (cnf map[string]interface{}, err error) {
-	buf, err := ioutil.ReadFile(path)
+	buf, err := os.ReadFile(path)
 	if err != nil {
 		return
 	}

--- a/core/logs/alils/log_project.go
+++ b/core/logs/alils/log_project.go
@@ -9,7 +9,7 @@ package alils
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httputil"
 )
@@ -51,7 +51,7 @@ func (p *LogProject) ListLogStore() (storeNames []string, err error) {
 		return
 	}
 
-	buf, err := ioutil.ReadAll(r.Body)
+	buf, err := io.ReadAll(r.Body)
 	if err != nil {
 		return
 	}
@@ -96,7 +96,7 @@ func (p *LogProject) GetLogStore(name string) (s *LogStore, err error) {
 		return
 	}
 
-	buf, err := ioutil.ReadAll(r.Body)
+	buf, err := io.ReadAll(r.Body)
 	if err != nil {
 		return
 	}
@@ -156,7 +156,7 @@ func (p *LogProject) CreateLogStore(name string, ttl, shardCnt int) (err error) 
 		return
 	}
 
-	body, err = ioutil.ReadAll(r.Body)
+	body, err = io.ReadAll(r.Body)
 	if err != nil {
 		return
 	}
@@ -188,7 +188,7 @@ func (p *LogProject) DeleteLogStore(name string) (err error) {
 		return
 	}
 
-	body, err := ioutil.ReadAll(r.Body)
+	body, err := io.ReadAll(r.Body)
 	if err != nil {
 		return
 	}
@@ -239,7 +239,7 @@ func (p *LogProject) UpdateLogStore(name string, ttl, shardCnt int) (err error) 
 		return
 	}
 
-	body, err = ioutil.ReadAll(r.Body)
+	body, err = io.ReadAll(r.Body)
 	if err != nil {
 		return
 	}
@@ -277,7 +277,7 @@ func (p *LogProject) ListMachineGroup(offset, size int) (m []string, total int, 
 		return
 	}
 
-	buf, err := ioutil.ReadAll(r.Body)
+	buf, err := io.ReadAll(r.Body)
 	if err != nil {
 		return
 	}
@@ -324,7 +324,7 @@ func (p *LogProject) GetMachineGroup(name string) (m *MachineGroup, err error) {
 		return
 	}
 
-	buf, err := ioutil.ReadAll(r.Body)
+	buf, err := io.ReadAll(r.Body)
 	if err != nil {
 		return
 	}
@@ -369,7 +369,7 @@ func (p *LogProject) CreateMachineGroup(m *MachineGroup) (err error) {
 		return
 	}
 
-	body, err = ioutil.ReadAll(r.Body)
+	body, err = io.ReadAll(r.Body)
 	if err != nil {
 		return
 	}
@@ -408,7 +408,7 @@ func (p *LogProject) UpdateMachineGroup(m *MachineGroup) (err error) {
 		return
 	}
 
-	body, err = ioutil.ReadAll(r.Body)
+	body, err = io.ReadAll(r.Body)
 	if err != nil {
 		return
 	}
@@ -440,7 +440,7 @@ func (p *LogProject) DeleteMachineGroup(name string) (err error) {
 		return
 	}
 
-	body, err := ioutil.ReadAll(r.Body)
+	body, err := io.ReadAll(r.Body)
 	if err != nil {
 		return
 	}
@@ -477,7 +477,7 @@ func (p *LogProject) ListConfig(offset, size int) (cfgNames []string, total int,
 		return
 	}
 
-	buf, err := ioutil.ReadAll(r.Body)
+	buf, err := io.ReadAll(r.Body)
 	if err != nil {
 		return
 	}
@@ -522,7 +522,7 @@ func (p *LogProject) GetConfig(name string) (c *LogConfig, err error) {
 		return
 	}
 
-	buf, err := ioutil.ReadAll(r.Body)
+	buf, err := io.ReadAll(r.Body)
 	if err != nil {
 		return
 	}
@@ -567,7 +567,7 @@ func (p *LogProject) UpdateConfig(c *LogConfig) (err error) {
 		return
 	}
 
-	body, err = ioutil.ReadAll(r.Body)
+	body, err = io.ReadAll(r.Body)
 	if err != nil {
 		return
 	}
@@ -606,7 +606,7 @@ func (p *LogProject) CreateConfig(c *LogConfig) (err error) {
 		return
 	}
 
-	body, err = ioutil.ReadAll(r.Body)
+	body, err = io.ReadAll(r.Body)
 	if err != nil {
 		return
 	}
@@ -638,7 +638,7 @@ func (p *LogProject) DeleteConfig(name string) (err error) {
 		return
 	}
 
-	body, err := ioutil.ReadAll(r.Body)
+	body, err := io.ReadAll(r.Body)
 	if err != nil {
 		return
 	}
@@ -670,7 +670,7 @@ func (p *LogProject) GetAppliedMachineGroups(confName string) (groupNames []stri
 		return
 	}
 
-	buf, err := ioutil.ReadAll(r.Body)
+	buf, err := io.ReadAll(r.Body)
 	if err != nil {
 		return
 	}
@@ -715,7 +715,7 @@ func (p *LogProject) GetAppliedConfigs(groupName string) (confNames []string, er
 		return
 	}
 
-	buf, err := ioutil.ReadAll(r.Body)
+	buf, err := io.ReadAll(r.Body)
 	if err != nil {
 		return
 	}
@@ -760,7 +760,7 @@ func (p *LogProject) ApplyConfigToMachineGroup(confName, groupName string) (err 
 		return
 	}
 
-	buf, err := ioutil.ReadAll(r.Body)
+	buf, err := io.ReadAll(r.Body)
 	if err != nil {
 		return
 	}
@@ -792,7 +792,7 @@ func (p *LogProject) RemoveConfigFromMachineGroup(confName, groupName string) (e
 		return
 	}
 
-	buf, err := ioutil.ReadAll(r.Body)
+	buf, err := io.ReadAll(r.Body)
 	if err != nil {
 		return
 	}

--- a/core/logs/alils/log_store.go
+++ b/core/logs/alils/log_store.go
@@ -3,7 +3,7 @@ package alils
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httputil"
 	"strconv"
@@ -41,7 +41,7 @@ func (s *LogStore) ListShards() (shardIDs []int, err error) {
 		return
 	}
 
-	buf, err := ioutil.ReadAll(r.Body)
+	buf, err := io.ReadAll(r.Body)
 	if err != nil {
 		return
 	}
@@ -98,7 +98,7 @@ func (s *LogStore) PutLogs(lg *LogGroup) (err error) {
 		return
 	}
 
-	buf, err := ioutil.ReadAll(r.Body)
+	buf, err := io.ReadAll(r.Body)
 	if err != nil {
 		return
 	}
@@ -134,7 +134,7 @@ func (s *LogStore) GetCursor(shardID int, from string) (cursor string, err error
 		return
 	}
 
-	buf, err := ioutil.ReadAll(r.Body)
+	buf, err := io.ReadAll(r.Body)
 	if err != nil {
 		return
 	}
@@ -185,7 +185,7 @@ func (s *LogStore) GetLogsBytes(shardID int, cursor string,
 		return
 	}
 
-	buf, err := ioutil.ReadAll(r.Body)
+	buf, err := io.ReadAll(r.Body)
 	if err != nil {
 		return
 	}

--- a/core/logs/alils/machine_group.go
+++ b/core/logs/alils/machine_group.go
@@ -3,7 +3,7 @@ package alils
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httputil"
 )
@@ -54,7 +54,7 @@ func (m *MachineGroup) ListMachines() (ms []*Machine, total int, err error) {
 		return
 	}
 
-	buf, err := ioutil.ReadAll(r.Body)
+	buf, err := io.ReadAll(r.Body)
 	if err != nil {
 		return
 	}

--- a/core/logs/file_test.go
+++ b/core/logs/file_test.go
@@ -17,7 +17,6 @@ package logs
 import (
 	"bufio"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strconv"
 	"testing"
@@ -378,7 +377,7 @@ func testFileDailyRotate(t *testing.T, fn1, fn2 string) {
 		if err != nil {
 			t.FailNow()
 		}
-		content, err := ioutil.ReadFile(file)
+		content, err := os.ReadFile(file)
 		if err != nil {
 			t.FailNow()
 		}
@@ -413,7 +412,7 @@ func testFileHourlyRotate(t *testing.T, fn1, fn2 string) {
 		if err != nil {
 			t.FailNow()
 		}
-		content, err := ioutil.ReadFile(file)
+		content, err := os.ReadFile(file)
 		if err != nil {
 			t.FailNow()
 		}

--- a/server/web/context/input.go
+++ b/server/web/context/input.go
@@ -19,7 +19,6 @@ import (
 	"compress/gzip"
 	"errors"
 	"io"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"net/url"
@@ -377,9 +376,9 @@ func (input *BeegoInput) CopyBody(MaxMemory int64) []byte {
 		if err != nil {
 			return nil
 		}
-		requestbody, _ = ioutil.ReadAll(reader)
+		requestbody, _ = io.ReadAll(reader)
 	} else {
-		requestbody, _ = ioutil.ReadAll(safe)
+		requestbody, _ = io.ReadAll(safe)
 	}
 
 	input.Context.Request.Body.Close()

--- a/server/web/context/input.go
+++ b/server/web/context/input.go
@@ -384,7 +384,7 @@ func (input *BeegoInput) CopyBody(MaxMemory int64) []byte {
 
 	input.Context.Request.Body.Close()
 	bf := bytes.NewBuffer(requestbody)
-	input.Context.Request.Body = http.MaxBytesReader(input.Context.ResponseWriter, ioutil.NopCloser(bf), MaxMemory)
+	input.Context.Request.Body = http.MaxBytesReader(input.Context.ResponseWriter, io.NopCloser(bf), MaxMemory)
 	input.RequestBody = requestbody
 	return requestbody
 }

--- a/server/web/controller_test.go
+++ b/server/web/controller_test.go
@@ -17,7 +17,6 @@ package web
 import (
 	"bytes"
 	"io"
-	"io/ioutil"
 	"math"
 	"mime/multipart"
 	"net/http"
@@ -321,7 +320,7 @@ func testControllerRespTestCases(t *testing.T, tc respTestCase) {
 		t.Errorf("TestResponse() failed to validate response code for %s", tc.Accept)
 	}
 
-	bodyBytes, err := ioutil.ReadAll(response.Body)
+	bodyBytes, err := io.ReadAll(response.Body)
 	if err != nil {
 		t.Errorf("TestResponse() failed to parse response body for %s", tc.Accept)
 	}

--- a/server/web/grace/server.go
+++ b/server/web/grace/server.go
@@ -5,7 +5,6 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"net"
 	"net/http"
@@ -194,7 +193,7 @@ func (srv *Server) ListenMutualTLS(certFile string, keyFile string, trustFile st
 	srv.TLSConfig.Certificates[0] = cert
 	srv.TLSConfig.ClientAuth = tls.RequireAndVerifyClientCert
 	pool := x509.NewCertPool()
-	data, err := ioutil.ReadFile(trustFile)
+	data, err := os.ReadFile(trustFile)
 	if err != nil {
 		log.Println(err)
 		return nil, err

--- a/server/web/server.go
+++ b/server/web/server.go
@@ -18,7 +18,6 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"net/http/fcgi"
@@ -257,7 +256,7 @@ func (app *HttpServer) Run(addr string, mws ...MiddleWare) {
 				app.Cfg.Listen.HTTPSCertFile, app.Cfg.Listen.HTTPSKeyFile = "", ""
 			} else if app.Cfg.Listen.EnableMutualHTTPS {
 				pool := x509.NewCertPool()
-				data, err := ioutil.ReadFile(app.Cfg.Listen.TrustCaFile)
+				data, err := os.ReadFile(app.Cfg.Listen.TrustCaFile)
 				if err != nil {
 					logs.Info("MutualHTTPS should provide TrustCaFile")
 					return

--- a/server/web/session/sess_file.go
+++ b/server/web/session/sess_file.go
@@ -258,7 +258,7 @@ func (fp *FileProvider) SessionRegenerate(ctx context.Context, oldsid, sid strin
 	// 4.return FileSessionStore
 	_, err = os.Stat(oldSidFile)
 	if err == nil {
-		b, err := ioutil.ReadFile(oldSidFile)
+		b, err := os.ReadFile(oldSidFile)
 		if err != nil {
 			return nil, err
 		}

--- a/server/web/session/sess_file.go
+++ b/server/web/session/sess_file.go
@@ -19,7 +19,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"path"
@@ -273,7 +272,7 @@ func (fp *FileProvider) SessionRegenerate(ctx context.Context, oldsid, sid strin
 			}
 		}
 
-		ioutil.WriteFile(newSidFile, b, 0o777)
+		os.WriteFile(newSidFile, b, 0o777)
 		os.Remove(oldSidFile)
 		os.Chtimes(newSidFile, time.Now(), time.Now())
 		ss := &FileSessionStore{sid: sid, values: kv}

--- a/server/web/session/sess_file.go
+++ b/server/web/session/sess_file.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"os"
@@ -167,7 +168,7 @@ func (fp *FileProvider) SessionRead(ctx context.Context, sid string) (Store, err
 
 	os.Chtimes(sidPath, time.Now(), time.Now())
 	var kv map[interface{}]interface{}
-	b, err := ioutil.ReadAll(f)
+	b, err := io.ReadAll(f)
 	if err != nil {
 		return nil, err
 	}

--- a/server/web/staticfile_test.go
+++ b/server/web/staticfile_test.go
@@ -6,7 +6,6 @@ import (
 	"compress/zlib"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -32,7 +31,7 @@ func testOpenFile(encoding string, content []byte, t *testing.T) {
 
 func TestOpenStaticFile_1(t *testing.T) {
 	file, _ := os.Open(licenseFile)
-	content, _ := ioutil.ReadAll(file)
+	content, _ := io.ReadAll(file)
 	testOpenFile("", content, t)
 }
 
@@ -42,7 +41,7 @@ func TestOpenStaticFileGzip_1(t *testing.T) {
 	fileWriter, _ := gzip.NewWriterLevel(&zipBuf, gzip.BestCompression)
 	io.Copy(fileWriter, file)
 	fileWriter.Close()
-	content, _ := ioutil.ReadAll(&zipBuf)
+	content, _ := io.ReadAll(&zipBuf)
 
 	testOpenFile("gzip", content, t)
 }
@@ -53,7 +52,7 @@ func TestOpenStaticFileDeflate_1(t *testing.T) {
 	fileWriter, _ := zlib.NewWriterLevel(&zipBuf, zlib.BestCompression)
 	io.Copy(fileWriter, file)
 	fileWriter.Close()
-	content, _ := ioutil.ReadAll(&zipBuf)
+	content, _ := io.ReadAll(&zipBuf)
 
 	testOpenFile("deflate", content, t)
 }
@@ -89,7 +88,7 @@ func assetOpenFileAndContent(sch *serveContentHolder, reader *serveContentReader
 		t.Log("static content file size not same")
 		t.Fail()
 	}
-	bs, _ := ioutil.ReadAll(reader)
+	bs, _ := io.ReadAll(reader)
 	for i, v := range content {
 		if v != bs[i] {
 			t.Log("content not same")

--- a/server/web/template.go
+++ b/server/web/template.go
@@ -19,7 +19,6 @@ import (
 	"fmt"
 	"html/template"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -250,7 +249,7 @@ func getTplDeep(root string, fs http.FileSystem, file string, parent string, t *
 		panic("can't find template file:" + file)
 	}
 	defer f.Close()
-	data, err := ioutil.ReadAll(f)
+	data, err := io.ReadAll(f)
 	if err != nil {
 		return nil, [][]string{}, err
 	}
@@ -324,7 +323,7 @@ func _getTemplate(t0 *template.Template, root string, fs http.FileSystem, subMod
 					logs.Trace("template file parse error, not success open file:", err)
 					continue
 				}
-				data, err = ioutil.ReadAll(f)
+				data, err = io.ReadAll(f)
 				f.Close()
 				if err != nil {
 					logs.Trace("template file parse error, not success read file:", err)


### PR DESCRIPTION
`io/ioutil` package has been deprecated since Go 1.16 as described [here](https://go.dev/doc/go1.16#ioutil).
So,I have fixed the relevant parts of the file except for [this auto-generated file](https://github.com/beego/beego/blob/develop/test/bindata.go).