### PR TITLE
refactor(server/web): remove redundant nil check

### DIFF
--- a/server/web/controller.go
+++ b/server/web/controller.go
@@ -312,19 +312,17 @@ func (c *Controller) RenderBytes() ([]byte, error) {
 	if err == nil && c.Layout != "" {
 		c.Data["LayoutContent"] = template.HTML(buf.String())
 
-		if c.LayoutSections != nil {
-			for sectionName, sectionTpl := range c.LayoutSections {
-				if sectionTpl == "" {
-					c.Data[sectionName] = ""
-					continue
-				}
-				buf.Reset()
-				err = ExecuteViewPathTemplate(&buf, sectionTpl, c.viewPath(), c.Data)
-				if err != nil {
-					return nil, err
-				}
-				c.Data[sectionName] = template.HTML(buf.String())
+		for sectionName, sectionTpl := range c.LayoutSections {
+			if sectionTpl == "" {
+				c.Data[sectionName] = ""
+				continue
 			}
+			buf.Reset()
+			err = ExecuteViewPathTemplate(&buf, sectionTpl, c.viewPath(), c.Data)
+			if err != nil {
+				return nil, err
+			}
+			c.Data[sectionName] = template.HTML(buf.String())
 		}
 
 		buf.Reset()
@@ -345,13 +343,11 @@ func (c *Controller) renderTemplate() (bytes.Buffer, error) {
 		buildFiles := []string{c.TplName}
 		if c.Layout != "" {
 			buildFiles = append(buildFiles, c.Layout)
-			if c.LayoutSections != nil {
-				for _, sectionTpl := range c.LayoutSections {
-					if sectionTpl == "" {
-						continue
-					}
-					buildFiles = append(buildFiles, sectionTpl)
+			for _, sectionTpl := range c.LayoutSections {
+				if sectionTpl == "" {
+					continue
 				}
+				buildFiles = append(buildFiles, sectionTpl)
 			}
 		}
 		BuildTemplate(c.viewPath(), buildFiles...)

--- a/server/web/router.go
+++ b/server/web/router.go
@@ -1357,19 +1357,15 @@ func (p *ControllerRegister) GetAllControllerInfo() (routerInfos []*ControllerIn
 }
 
 func composeControllerInfos(tree *Tree, routerInfos *[]*ControllerInfo) {
-	if tree.fixrouters != nil {
-		for _, subTree := range tree.fixrouters {
-			composeControllerInfos(subTree, routerInfos)
-		}
+	for _, subTree := range tree.fixrouters {
+		composeControllerInfos(subTree, routerInfos)
 	}
 	if tree.wildcard != nil {
 		composeControllerInfos(tree.wildcard, routerInfos)
 	}
-	if tree.leaves != nil {
-		for _, l := range tree.leaves {
-			if c, ok := l.runObject.(*ControllerInfo); ok {
-				*routerInfos = append(*routerInfos, c)
-			}
+	for _, l := range tree.leaves {
+		if c, ok := l.runObject.(*ControllerInfo); ok {
+			*routerInfos = append(*routerInfos, c)
 		}
 	}
 }


### PR DESCRIPTION
From the Go specification (https://go.dev/ref/spec#For_range):

> "1. For a nil slice, the number of iterations is 0."
> "3. If the map is nil, the number of iterations is 0."

Therefore, an additional nil check for slice and map before the loop is unnecessary.