### PR TITLE
Fix issue 5537 - Send missing app.conf ini error to STDERR

### DIFF
--- a/core/config/ini.go
+++ b/core/config/ini.go
@@ -19,6 +19,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"os"
 	"os/user"
@@ -28,8 +29,6 @@ import (
 	"sync"
 
 	"github.com/mitchellh/mapstructure"
-
-	"github.com/beego/beego/v2/core/logs"
 )
 
 var (
@@ -519,7 +518,7 @@ func init() {
 
 	err := InitGlobalInstance("ini", "conf/app.conf")
 	if err != nil {
-		logs.Debug("init global config instance failed. If you do not use this, just ignore it. ", err)
+		fmt.Fprint(os.Stderr, "init global config instance failed. If you do not use this, just ignore it. ", err)
 	}
 }
 


### PR DESCRIPTION
Send "ignorable" error message for missing `conf/app.conf` to STDERR instead of using logger.