### PR TITLE
Fixed the issue that the information was displayed on the same line

### DIFF
--- a/core/config/ini.go
+++ b/core/config/ini.go
@@ -19,6 +19,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"os"
 	"os/user"
@@ -28,8 +29,6 @@ import (
 	"sync"
 
 	"github.com/mitchellh/mapstructure"
-
-	"github.com/beego/beego/v2/core/logs"
 )
 
 var (
@@ -519,7 +518,7 @@ func init() {
 
 	err := InitGlobalInstance("ini", "conf/app.conf")
 	if err != nil {
-		logs.Debug("init global config instance failed. If you do not use this, just ignore it. ", err)
+		_, _ = fmt.Fprintln(os.Stderr, "init global config instance failed. If you do not use this, just ignore it. ", err)
 	}
 }
 


### PR DESCRIPTION
MR5538 change will cause the console to be displayed on the same line as the next output,in `core/config/ini.go`

Before modification
```go
fmt.Fprint(os.Stderr, "init global config instance failed. If you do not use this, just ignore it. ", err)
```
After modification
```go
_, _ = fmt.Fprintln(os.Stderr, "init global config instance failed. If you do not use this, just ignore it. ", err)
```
