### PR TITLE
refactor: replace deprecated `github.com/pkg/errors` with `errors` pkg

### DIFF
--- a/client/orm/orm_raw.go
+++ b/client/orm/orm_raw.go
@@ -16,15 +16,13 @@ package orm
 
 import (
 	"database/sql"
+	"errors"
 	"fmt"
 	"reflect"
 	"time"
 
-	"github.com/beego/beego/v2/client/orm/internal/utils"
-
 	"github.com/beego/beego/v2/client/orm/internal/models"
-
-	"github.com/pkg/errors"
+	"github.com/beego/beego/v2/client/orm/internal/utils"
 )
 
 // raw sql string prepared statement
@@ -299,7 +297,7 @@ func (o *rawSet) QueryRow(containers ...interface{}) error {
 		ind := reflect.Indirect(val)
 
 		if val.Kind() != reflect.Ptr {
-			panic(fmt.Errorf("<RawSeter.QueryRow> All args must be use ptr"))
+			panic(errors.New("<RawSeter.QueryRow> All args must be use ptr"))
 		}
 
 		etyp := ind.Type()
@@ -313,7 +311,7 @@ func (o *rawSet) QueryRow(containers ...interface{}) error {
 
 		if typ.Kind() == reflect.Struct && typ.String() != "time.Time" {
 			if len(containers) > 1 {
-				panic(fmt.Errorf("<RawSeter.QueryRow> now support one struct only. see #384"))
+				panic(errors.New("<RawSeter.QueryRow> now support one struct only. see #384"))
 			}
 
 			structMode = true
@@ -386,7 +384,7 @@ func (o *rawSet) QueryRow(containers ...interface{}) error {
 							fd := field.Addr().Interface().(models.Fielder)
 							err := fd.SetRaw(value)
 							if err != nil {
-								return errors.Errorf("Set raw error:%s", err)
+								return fmt.Errorf("Set raw error: %w", err)
 							}
 						} else {
 							o.setFieldValue(field, value)
@@ -460,7 +458,7 @@ func (o *rawSet) QueryRows(containers ...interface{}) (int64, error) {
 		val := reflect.ValueOf(container)
 		sInd := reflect.Indirect(val)
 		if val.Kind() != reflect.Ptr || sInd.Kind() != reflect.Slice {
-			panic(fmt.Errorf("<RawSeter.QueryRows> All args must be use ptr slice"))
+			panic(errors.New("<RawSeter.QueryRows> All args must be use ptr slice"))
 		}
 
 		etyp := sInd.Type().Elem()
@@ -474,7 +472,7 @@ func (o *rawSet) QueryRows(containers ...interface{}) (int64, error) {
 
 		if typ.Kind() == reflect.Struct && typ.String() != "time.Time" {
 			if len(containers) > 1 {
-				panic(fmt.Errorf("<RawSeter.QueryRow> now support one struct only. see #384"))
+				panic(errors.New("<RawSeter.QueryRow> now support one struct only. see #384"))
 			}
 
 			structMode = true
@@ -552,7 +550,7 @@ func (o *rawSet) QueryRows(containers ...interface{}) (int64, error) {
 							fd := field.Addr().Interface().(models.Fielder)
 							err := fd.SetRaw(value)
 							if err != nil {
-								return 0, errors.Errorf("Set raw error:%s", err)
+								return 0, fmt.Errorf("Set raw error: %w", err)
 							}
 						} else {
 							o.setFieldValue(field, value)

--- a/core/admin/command.go
+++ b/core/admin/command.go
@@ -15,7 +15,7 @@
 package admin
 
 import (
-	"github.com/pkg/errors"
+	"errors"
 )
 
 // Command is an experimental interface

--- a/core/bean/tag_auto_wire_bean_factory.go
+++ b/core/bean/tag_auto_wire_bean_factory.go
@@ -20,8 +20,6 @@ import (
 	"reflect"
 	"strconv"
 
-	"github.com/pkg/errors"
-
 	"github.com/beego/beego/v2/core/logs"
 )
 
@@ -92,9 +90,8 @@ func (t *TagAutoWireBeanFactory) AutoWire(ctx context.Context, appCtx Applicatio
 		switch fValue.Kind() {
 		case reflect.Bool:
 			if v, err := strconv.ParseBool(fm.DftValue); err != nil {
-				return errors.WithMessage(err,
-					fmt.Sprintf("can not convert the field[%s]'s default value[%s] to bool value",
-						fn, fm.DftValue))
+				return fmt.Errorf("can not convert the field[%s]'s default value[%s] to bool value: %w",
+					fn, fm.DftValue, err)
 			} else {
 				fValue.SetBool(v)
 				continue
@@ -182,9 +179,8 @@ func (t *TagAutoWireBeanFactory) AutoWire(ctx context.Context, appCtx Applicatio
 
 func (t *TagAutoWireBeanFactory) setFloatXValue(dftValue string, bitSize int, fn string, fv reflect.Value) error {
 	if v, err := strconv.ParseFloat(dftValue, bitSize); err != nil {
-		return errors.WithMessage(err,
-			fmt.Sprintf("can not convert the field[%s]'s default value[%s] to float%d value",
-				fn, dftValue, bitSize))
+		return fmt.Errorf("can not convert the field[%s]'s default value[%s] to float%d value: %w",
+			fn, dftValue, bitSize, err)
 	} else {
 		fv.SetFloat(v)
 		return nil
@@ -193,9 +189,8 @@ func (t *TagAutoWireBeanFactory) setFloatXValue(dftValue string, bitSize int, fn
 
 func (t *TagAutoWireBeanFactory) setUIntXValue(dftValue string, bitSize int, fn string, fv reflect.Value) error {
 	if v, err := strconv.ParseUint(dftValue, 10, bitSize); err != nil {
-		return errors.WithMessage(err,
-			fmt.Sprintf("can not convert the field[%s]'s default value[%s] to uint%d value",
-				fn, dftValue, bitSize))
+		return fmt.Errorf("can not convert the field[%s]'s default value[%s] to uint%d value: %w",
+			fn, dftValue, bitSize, err)
 	} else {
 		fv.SetUint(v)
 		return nil
@@ -204,9 +199,8 @@ func (t *TagAutoWireBeanFactory) setUIntXValue(dftValue string, bitSize int, fn 
 
 func (t *TagAutoWireBeanFactory) setIntXValue(dftValue string, bitSize int, fn string, fv reflect.Value) error {
 	if v, err := strconv.ParseInt(dftValue, 10, bitSize); err != nil {
-		return errors.WithMessage(err,
-			fmt.Sprintf("can not convert the field[%s]'s default value[%s] to int%d value",
-				fn, dftValue, bitSize))
+		return fmt.Errorf("can not convert the field[%s]'s default value[%s] to int%d value: %w",
+			fn, dftValue, bitSize, err)
 	} else {
 		fv.SetInt(v)
 		return nil

--- a/core/berror/error.go
+++ b/core/berror/error.go
@@ -18,8 +18,6 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
-
-	"github.com/pkg/errors"
 )
 
 // code, msg
@@ -39,7 +37,7 @@ func Wrap(err error, c Code, msg string) error {
 	if err == nil {
 		return nil
 	}
-	return errors.Wrap(err, fmt.Sprintf(errFmt, c.Code(), msg))
+	return fmt.Errorf(errFmt+": %w", c.Code(), msg, err)
 }
 
 func Wrapf(err error, c Code, format string, a ...interface{}) error {

--- a/core/config/error.go
+++ b/core/config/error.go
@@ -15,7 +15,7 @@
 package config
 
 import (
-	"github.com/pkg/errors"
+	"errors"
 )
 
 // now not all implementation return those error codes

--- a/core/logs/alils/alils.go
+++ b/core/logs/alils/alils.go
@@ -7,7 +7,6 @@ import (
 	"sync"
 
 	"github.com/gogo/protobuf/proto"
-	"github.com/pkg/errors"
 
 	"github.com/beego/beego/v2/core/logs"
 )
@@ -110,7 +109,7 @@ func (c *aliLSWriter) Init(config string) error {
 	if len(c.Formatter) > 0 {
 		fmtr, ok := logs.GetFormatter(c.Formatter)
 		if !ok {
-			return errors.New(fmt.Sprintf("the formatter with name: %s not found", c.Formatter))
+			return fmt.Errorf("the formatter with name: %s not found", c.Formatter)
 		}
 		c.formatter = fmtr
 	}

--- a/core/logs/conn.go
+++ b/core/logs/conn.go
@@ -19,8 +19,6 @@ import (
 	"fmt"
 	"io"
 	"net"
-
-	"github.com/pkg/errors"
 )
 
 // connWriter implements LoggerInterface.
@@ -56,7 +54,7 @@ func (c *connWriter) Init(config string) error {
 	if res == nil && len(c.Formatter) > 0 {
 		fmtr, ok := GetFormatter(c.Formatter)
 		if !ok {
-			return errors.New(fmt.Sprintf("the formatter with name: %s not found", c.Formatter))
+			return fmt.Errorf("the formatter with name: %s not found", c.Formatter)
 		}
 		c.formatter = fmtr
 	}

--- a/core/logs/console.go
+++ b/core/logs/console.go
@@ -20,7 +20,6 @@ import (
 	"os"
 	"strings"
 
-	"github.com/pkg/errors"
 	"github.com/shiena/ansicolor"
 )
 
@@ -95,7 +94,7 @@ func (c *consoleWriter) Init(config string) error {
 	if res == nil && len(c.Formatter) > 0 {
 		fmtr, ok := GetFormatter(c.Formatter)
 		if !ok {
-			return errors.New(fmt.Sprintf("the formatter with name: %s not found", c.Formatter))
+			return fmt.Errorf("the formatter with name: %s not found", c.Formatter)
 		}
 		c.formatter = fmtr
 	}

--- a/core/logs/jianliao.go
+++ b/core/logs/jianliao.go
@@ -5,8 +5,6 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
-
-	"github.com/pkg/errors"
 )
 
 // JLWriter implements beego LoggerInterface and is used to send jiaoliao webhook
@@ -35,7 +33,7 @@ func (s *JLWriter) Init(config string) error {
 	if res == nil && len(s.Formatter) > 0 {
 		fmtr, ok := GetFormatter(s.Formatter)
 		if !ok {
-			return errors.New(fmt.Sprintf("the formatter with name: %s not found", s.Formatter))
+			return fmt.Errorf("the formatter with name: %s not found", s.Formatter)
 		}
 		s.formatter = fmtr
 	}

--- a/core/logs/slack.go
+++ b/core/logs/slack.go
@@ -5,8 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-
-	"github.com/pkg/errors"
 )
 
 // SLACKWriter implements beego LoggerInterface and is used to send jiaoliao webhook
@@ -40,7 +38,7 @@ func (s *SLACKWriter) Init(config string) error {
 	if res == nil && len(s.Formatter) > 0 {
 		fmtr, ok := GetFormatter(s.Formatter)
 		if !ok {
-			return errors.New(fmt.Sprintf("the formatter with name: %s not found", s.Formatter))
+			return fmt.Errorf("the formatter with name: %s not found", s.Formatter)
 		}
 		s.formatter = fmtr
 	}

--- a/core/logs/smtp.go
+++ b/core/logs/smtp.go
@@ -21,8 +21,6 @@ import (
 	"net"
 	"net/smtp"
 	"strings"
-
-	"github.com/pkg/errors"
 )
 
 // SMTPWriter implements LoggerInterface and is used to send emails via given SMTP-server.
@@ -62,7 +60,7 @@ func (s *SMTPWriter) Init(config string) error {
 	if res == nil && len(s.Formatter) > 0 {
 		fmtr, ok := GetFormatter(s.Formatter)
 		if !ok {
-			return errors.New(fmt.Sprintf("the formatter with name: %s not found", s.Formatter))
+			return fmt.Errorf("the formatter with name: %s not found", s.Formatter)
 		}
 		s.formatter = fmtr
 	}

--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,6 @@ require (
 	github.com/mitchellh/mapstructure v1.5.0
 	github.com/opentracing/opentracing-go v1.2.0
 	github.com/pelletier/go-toml v1.9.2
-	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.16.0
 	github.com/shiena/ansicolor v0.0.0-20200904210342-c7312218db18
 	github.com/ssdb/gossdb v0.0.0-20180723034631-88f6b59b84ec
@@ -62,6 +61,7 @@ require (
 	github.com/golang/protobuf v1.5.3 // indirect
 	github.com/golang/snappy v0.0.0-20180518054509-2e65f85255db // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.4 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/client_model v0.3.0 // indirect
 	github.com/prometheus/common v0.42.0 // indirect

--- a/task/govenor_command.go
+++ b/task/govenor_command.go
@@ -16,10 +16,9 @@ package task
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"html/template"
-
-	"github.com/pkg/errors"
 
 	"github.com/beego/beego/v2/core/admin"
 )
@@ -78,7 +77,7 @@ func (r *runTaskCommand) Execute(params ...interface{}) *admin.Result {
 	} else {
 		return &admin.Result{
 			Status: 400,
-			Error:  errors.New(fmt.Sprintf("task with name %s not found", tn)),
+			Error:  fmt.Errorf("task with name %s not found", tn),
 		}
 	}
 }


### PR DESCRIPTION
This PR replaces the deprecated package [github.com/pkg/errors](https://github.com/pkg/errors) with the native errors [package](https://pkg.go.dev/errors).