### PR TITLE
upgrade to go-redis/v9

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,6 @@ require (
 	github.com/elazarl/go-bindata-assetfs v1.0.1
 	github.com/go-kit/kit v0.12.1-0.20220826005032-a7ba4fa4e289
 	github.com/go-kit/log v0.2.1
-	github.com/go-redis/redis/v7 v7.4.0
 	github.com/go-sql-driver/mysql v1.7.0
 	github.com/gogo/protobuf v1.3.2
 	github.com/gomodule/redigo v2.0.0+incompatible
@@ -54,6 +53,7 @@ require (
 	github.com/couchbase/goutils v0.1.0 // indirect
 	github.com/cupcake/rdb v0.0.0-20161107195141-43ba34106c76 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
 	github.com/edsrzf/mmap-go v1.0.0 // indirect
 	github.com/go-logfmt/logfmt v0.5.1 // indirect
 	github.com/go-logr/logr v1.2.3 // indirect
@@ -66,6 +66,7 @@ require (
 	github.com/prometheus/client_model v0.3.0 // indirect
 	github.com/prometheus/common v0.42.0 // indirect
 	github.com/prometheus/procfs v0.10.1 // indirect
+	github.com/redis/go-redis/v9 v9.5.1 // indirect
 	github.com/rogpeppe/go-internal v1.10.0 // indirect
 	github.com/siddontang/go v0.0.0-20170517070808-cb568a3e5cc0 // indirect
 	github.com/siddontang/rdb v0.0.0-20150307021120-fc89ed2e418d // indirect

--- a/go.sum
+++ b/go.sum
@@ -48,6 +48,8 @@ github.com/cupcake/rdb v0.0.0-20161107195141-43ba34106c76/go.mod h1:vYwsqCOLxGii
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f h1:lO4WD4F/rVNCu3HqELle0jiPLLBs70cWOduZpkS1E78=
+github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f/go.mod h1:cuUVRXasLTGF7a8hSLbxyZXjz+1KgoB3wDUb6vlszIc=
 github.com/edsrzf/mmap-go v0.0.0-20170320065105-0bce6a688712/go.mod h1:YO35OhQPt3KJa3ryjFM5Bs14WD66h8eGKpfaBNrHW5M=
 github.com/edsrzf/mmap-go v1.0.0 h1:CEBF7HpRnUCSJgGUb5h1Gm7e3VkmVDrR8lvWVLtrOFw=
 github.com/edsrzf/mmap-go v1.0.0/go.mod h1:YO35OhQPt3KJa3ryjFM5Bs14WD66h8eGKpfaBNrHW5M=
@@ -76,8 +78,6 @@ github.com/go-logr/logr v1.2.3 h1:2DntVwHkVopvECVRSlL5PSo9eG+cAkDCuckLubN+rq0=
 github.com/go-logr/logr v1.2.3/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-logr/stdr v1.2.2 h1:hSWxHoqTgW2S2qGc0LTAI563KZ5YKYRhT3MFKZMbjag=
 github.com/go-logr/stdr v1.2.2/go.mod h1:mMo/vtBO5dYbehREoey6XUKy/eSumjCCveDpRre4VKE=
-github.com/go-redis/redis/v7 v7.4.0 h1:7obg6wUoj05T0EpY0o8B59S9w5yeMWql7sw2kwNW1x4=
-github.com/go-redis/redis/v7 v7.4.0/go.mod h1:JDNMw23GTyLNC4GZu9njt15ctBQVn7xjRfnwdHj/Dcg=
 github.com/go-sql-driver/mysql v1.7.0 h1:ueSltNNllEqE3qcWBTD0iQd3IpL/6U+mJxLkazJ7YPc=
 github.com/go-sql-driver/mysql v1.7.0/go.mod h1:OXbVy3sEdcQ2Doequ6Z5BW6fXNQTmx+9S1MCJN5yJMI=
 github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
@@ -168,6 +168,8 @@ github.com/prometheus/common v0.42.0 h1:EKsfXEYo4JpWMHH5cg+KOUWeuJSov1Id8zGR8eeI
 github.com/prometheus/common v0.42.0/go.mod h1:xBwqVerjNdUDjgODMpudtOMwlOwf2SaTr1yjz4b7Zbc=
 github.com/prometheus/procfs v0.10.1 h1:kYK1Va/YMlutzCGazswoHKo//tZVlFpKYh+PymziUAg=
 github.com/prometheus/procfs v0.10.1/go.mod h1:nwNm2aOCAYw8uTR/9bWRREkZFxAUcWzPHWJq+XBB/FM=
+github.com/redis/go-redis/v9 v9.5.1 h1:H1X4D3yHPaYrkL5X06Wh6xNVM/pX0Ft4RV0vMGvLBh8=
+github.com/redis/go-redis/v9 v9.5.1/go.mod h1:hdY0cQFCN4fnSYT6TkisLufl/4W5UIXyv0b/CLO2V2M=
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
 github.com/rogpeppe/go-internal v1.10.0 h1:TMyTOH3F/DB16zRVcYyreMH6GnZZrwQVAoYjRBZyWFQ=
 github.com/rogpeppe/go-internal v1.10.0/go.mod h1:UQnix2H7Ngw/k4C5ijL5+65zddjncjaFoBhdsK/akog=

--- a/server/web/router.go
+++ b/server/web/router.go
@@ -15,6 +15,7 @@
 package web
 
 import (
+	"context"
 	"bytes"
 	"errors"
 	"fmt"
@@ -1100,7 +1101,7 @@ func (p *ControllerRegister) serveHttp(ctx *beecontext.Context) {
 		}
 		defer func() {
 			if ctx.Input.CruSession != nil {
-				ctx.Input.CruSession.SessionRelease(nil, rw)
+				ctx.Input.CruSession.SessionRelease(context.Background(), rw)
 			}
 		}()
 	}

--- a/server/web/session/redis/sess_redis.go
+++ b/server/web/session/redis/sess_redis.go
@@ -41,7 +41,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/go-redis/redis/v7"
+	"github.com/redis/go-redis/v9"
 
 	"github.com/beego/beego/v2/server/web/session"
 )
@@ -109,7 +109,7 @@ func (rs *SessionStore) SessionRelease(ctx context.Context, w http.ResponseWrite
 		return
 	}
 	c := rs.p
-	c.Set(rs.sid, string(b), time.Duration(rs.maxlifetime)*time.Second)
+	c.Set(ctx, rs.sid, string(b), time.Duration(rs.maxlifetime)*time.Second)
 }
 
 // Provider redis session provider
@@ -162,12 +162,11 @@ func (rp *Provider) SessionInit(ctx context.Context, maxlifetime int64, cfgStr s
 		Password:           rp.Password,
 		PoolSize:           rp.Poolsize,
 		DB:                 rp.DbNum,
-		IdleTimeout:        rp.idleTimeout,
-		IdleCheckFrequency: rp.idleCheckFrequency,
+		ConnMaxIdleTime:    rp.idleTimeout,
 		MaxRetries:         rp.MaxRetries,
 	})
 
-	return rp.poollist.Ping().Err()
+	return rp.poollist.Ping(ctx).Err()
 }
 
 func (rp *Provider) initOldStyle(savePath string) {
@@ -222,7 +221,7 @@ func (rp *Provider) initOldStyle(savePath string) {
 func (rp *Provider) SessionRead(ctx context.Context, sid string) (session.Store, error) {
 	var kv map[interface{}]interface{}
 
-	kvs, err := rp.poollist.Get(sid).Result()
+	kvs, err := rp.poollist.Get(ctx, sid).Result()
 	if err != nil && err != redis.Nil {
 		return nil, err
 	}
@@ -242,7 +241,7 @@ func (rp *Provider) SessionRead(ctx context.Context, sid string) (session.Store,
 func (rp *Provider) SessionExist(ctx context.Context, sid string) (bool, error) {
 	c := rp.poollist
 
-	if existed, err := c.Exists(sid).Result(); err != nil || existed == 0 {
+	if existed, err := c.Exists(ctx, sid).Result(); err != nil || existed == 0 {
 		return false, err
 	}
 	return true, nil
@@ -251,23 +250,23 @@ func (rp *Provider) SessionExist(ctx context.Context, sid string) (bool, error) 
 // SessionRegenerate generate new sid for redis session
 func (rp *Provider) SessionRegenerate(ctx context.Context, oldsid, sid string) (session.Store, error) {
 	c := rp.poollist
-	if existed, _ := c.Exists(oldsid).Result(); existed == 0 {
+	if existed, _ := c.Exists(ctx, oldsid).Result(); existed == 0 {
 		// oldsid doesn't exists, set the new sid directly
 		// ignore error here, since if it return error
 		// the existed value will be 0
-		c.Do(c.Context(), "SET", sid, "", "EX", rp.maxlifetime)
+		c.Do(ctx, "SET", sid, "", "EX", rp.maxlifetime)
 	} else {
-		c.Rename(oldsid, sid)
-		c.Expire(sid, time.Duration(rp.maxlifetime)*time.Second)
+		c.Rename(ctx, oldsid, sid)
+		c.Expire(ctx, sid, time.Duration(rp.maxlifetime)*time.Second)
 	}
-	return rp.SessionRead(context.Background(), sid)
+	return rp.SessionRead(ctx, sid)
 }
 
 // SessionDestroy delete redis session by id
 func (rp *Provider) SessionDestroy(ctx context.Context, sid string) error {
 	c := rp.poollist
 
-	c.Del(sid)
+	c.Del(ctx, sid)
 	return nil
 }
 

--- a/server/web/session/redis/sess_redis_test.go
+++ b/server/web/session/redis/sess_redis_test.go
@@ -38,6 +38,8 @@ func TestRedis(t *testing.T) {
 
 	go globalSession.GC()
 
+	ctx := context.Background()
+
 	r, _ := http.NewRequest("GET", "/", nil)
 	w := httptest.NewRecorder()
 
@@ -45,59 +47,59 @@ func TestRedis(t *testing.T) {
 	if err != nil {
 		t.Fatal("session start failed:", err)
 	}
-	defer sess.SessionRelease(nil, w)
+	defer sess.SessionRelease(ctx, w)
 
 	// SET AND GET
-	err = sess.Set(nil, "username", "astaxie")
+	err = sess.Set(ctx, "username", "astaxie")
 	if err != nil {
 		t.Fatal("set username failed:", err)
 	}
-	username := sess.Get(nil, "username")
+	username := sess.Get(ctx, "username")
 	if username != "astaxie" {
 		t.Fatal("get username failed")
 	}
 
 	// DELETE
-	err = sess.Delete(nil, "username")
+	err = sess.Delete(ctx, "username")
 	if err != nil {
 		t.Fatal("delete username failed:", err)
 	}
-	username = sess.Get(nil, "username")
+	username = sess.Get(ctx, "username")
 	if username != nil {
 		t.Fatal("delete username failed")
 	}
 
 	// FLUSH
-	err = sess.Set(nil, "username", "astaxie")
+	err = sess.Set(ctx, "username", "astaxie")
 	if err != nil {
 		t.Fatal("set failed:", err)
 	}
-	err = sess.Set(nil, "password", "1qaz2wsx")
+	err = sess.Set(ctx, "password", "1qaz2wsx")
 	if err != nil {
 		t.Fatal("set failed:", err)
 	}
-	username = sess.Get(nil, "username")
+	username = sess.Get(ctx, "username")
 	if username != "astaxie" {
 		t.Fatal("get username failed")
 	}
-	password := sess.Get(nil, "password")
+	password := sess.Get(ctx, "password")
 	if password != "1qaz2wsx" {
 		t.Fatal("get password failed")
 	}
-	err = sess.Flush(nil)
+	err = sess.Flush(ctx)
 	if err != nil {
 		t.Fatal("flush failed:", err)
 	}
-	username = sess.Get(nil, "username")
+	username = sess.Get(ctx, "username")
 	if username != nil {
 		t.Fatal("flush failed")
 	}
-	password = sess.Get(nil, "password")
+	password = sess.Get(ctx, "password")
 	if password != nil {
 		t.Fatal("flush failed")
 	}
 
-	sess.SessionRelease(nil, w)
+	sess.SessionRelease(ctx, w)
 }
 
 func TestProvider_SessionInit(t *testing.T) {

--- a/server/web/session/redis_cluster/redis_cluster.go
+++ b/server/web/session/redis_cluster/redis_cluster.go
@@ -14,9 +14,9 @@
 
 // Package redis for session provider
 //
-// depend on github.com/go-redis/redis
+// depend on github.com/redis/go-redis
 //
-// go install github.com/go-redis/redis
+// go install github.com/redis/go-redis
 //
 // Usage:
 // import(
@@ -41,7 +41,7 @@ import (
 	"sync"
 	"time"
 
-	rediss "github.com/go-redis/redis/v7"
+	rediss "github.com/redis/go-redis/v9"
 
 	"github.com/beego/beego/v2/server/web/session"
 )
@@ -109,7 +109,7 @@ func (rs *SessionStore) SessionRelease(ctx context.Context, w http.ResponseWrite
 		return
 	}
 	c := rs.p
-	c.Set(rs.sid, string(b), time.Duration(rs.maxlifetime)*time.Second)
+	c.Set(ctx, rs.sid, string(b), time.Duration(rs.maxlifetime)*time.Second)
 }
 
 // Provider redis_cluster session provider
@@ -159,11 +159,10 @@ func (rp *Provider) SessionInit(ctx context.Context, maxlifetime int64, cfgStr s
 		Addrs:              strings.Split(rp.SavePath, ";"),
 		Password:           rp.Password,
 		PoolSize:           rp.Poolsize,
-		IdleTimeout:        rp.idleTimeout,
-		IdleCheckFrequency: rp.idleCheckFrequency,
+		ConnMaxIdleTime:    rp.idleTimeout,
 		MaxRetries:         rp.MaxRetries,
 	})
-	return rp.poollist.Ping().Err()
+	return rp.poollist.Ping(ctx).Err()
 }
 
 // for v1.x
@@ -218,7 +217,7 @@ func (rp *Provider) initOldStyle(savePath string) {
 // SessionRead read redis_cluster session by sid
 func (rp *Provider) SessionRead(ctx context.Context, sid string) (session.Store, error) {
 	var kv map[interface{}]interface{}
-	kvs, err := rp.poollist.Get(sid).Result()
+	kvs, err := rp.poollist.Get(ctx, sid).Result()
 	if err != nil && err != rediss.Nil {
 		return nil, err
 	}
@@ -237,7 +236,7 @@ func (rp *Provider) SessionRead(ctx context.Context, sid string) (session.Store,
 // SessionExist check redis_cluster session exist by sid
 func (rp *Provider) SessionExist(ctx context.Context, sid string) (bool, error) {
 	c := rp.poollist
-	if existed, err := c.Exists(sid).Result(); err != nil || existed == 0 {
+	if existed, err := c.Exists(ctx, sid).Result(); err != nil || existed == 0 {
 		return false, err
 	}
 	return true, nil
@@ -247,22 +246,22 @@ func (rp *Provider) SessionExist(ctx context.Context, sid string) (bool, error) 
 func (rp *Provider) SessionRegenerate(ctx context.Context, oldsid, sid string) (session.Store, error) {
 	c := rp.poollist
 
-	if existed, err := c.Exists(oldsid).Result(); err != nil || existed == 0 {
+	if existed, err := c.Exists(ctx, oldsid).Result(); err != nil || existed == 0 {
 		// oldsid doesn't exists, set the new sid directly
 		// ignore error here, since if it return error
 		// the existed value will be 0
-		c.Set(sid, "", time.Duration(rp.maxlifetime)*time.Second)
+		c.Set(ctx, sid, "", time.Duration(rp.maxlifetime)*time.Second)
 	} else {
-		c.Rename(oldsid, sid)
-		c.Expire(sid, time.Duration(rp.maxlifetime)*time.Second)
+		c.Rename(ctx, oldsid, sid)
+		c.Expire(ctx, sid, time.Duration(rp.maxlifetime)*time.Second)
 	}
-	return rp.SessionRead(context.Background(), sid)
+	return rp.SessionRead(ctx, sid)
 }
 
 // SessionDestroy delete redis session by id
 func (rp *Provider) SessionDestroy(ctx context.Context, sid string) error {
 	c := rp.poollist
-	c.Del(sid)
+	c.Del(ctx, sid)
 	return nil
 }
 

--- a/server/web/session/redis_sentinel/sess_redis_sentinel_test.go
+++ b/server/web/session/redis_sentinel/sess_redis_sentinel_test.go
@@ -30,6 +30,8 @@ func TestRedisSentinel(t *testing.T) {
 	// todo test if e==nil
 	go globalSessions.GC()
 
+	ctx := context.Background()
+
 	r, _ := http.NewRequest("GET", "/", nil)
 	w := httptest.NewRecorder()
 
@@ -37,59 +39,59 @@ func TestRedisSentinel(t *testing.T) {
 	if err != nil {
 		t.Fatal("session start failed:", err)
 	}
-	defer sess.SessionRelease(nil, w)
+	defer sess.SessionRelease(ctx, w)
 
 	// SET AND GET
-	err = sess.Set(nil, "username", "astaxie")
+	err = sess.Set(ctx, "username", "astaxie")
 	if err != nil {
 		t.Fatal("set username failed:", err)
 	}
-	username := sess.Get(nil, "username")
+	username := sess.Get(ctx, "username")
 	if username != "astaxie" {
 		t.Fatal("get username failed")
 	}
 
 	// DELETE
-	err = sess.Delete(nil, "username")
+	err = sess.Delete(ctx, "username")
 	if err != nil {
 		t.Fatal("delete username failed:", err)
 	}
-	username = sess.Get(nil, "username")
+	username = sess.Get(ctx, "username")
 	if username != nil {
 		t.Fatal("delete username failed")
 	}
 
 	// FLUSH
-	err = sess.Set(nil, "username", "astaxie")
+	err = sess.Set(ctx, "username", "astaxie")
 	if err != nil {
 		t.Fatal("set failed:", err)
 	}
-	err = sess.Set(nil, "password", "1qaz2wsx")
+	err = sess.Set(ctx, "password", "1qaz2wsx")
 	if err != nil {
 		t.Fatal("set failed:", err)
 	}
-	username = sess.Get(nil, "username")
+	username = sess.Get(ctx, "username")
 	if username != "astaxie" {
 		t.Fatal("get username failed")
 	}
-	password := sess.Get(nil, "password")
+	password := sess.Get(ctx, "password")
 	if password != "1qaz2wsx" {
 		t.Fatal("get password failed")
 	}
-	err = sess.Flush(nil)
+	err = sess.Flush(ctx)
 	if err != nil {
 		t.Fatal("flush failed:", err)
 	}
-	username = sess.Get(nil, "username")
+	username = sess.Get(ctx, "username")
 	if username != nil {
 		t.Fatal("flush failed")
 	}
-	password = sess.Get(nil, "password")
+	password = sess.Get(ctx, "password")
 	if password != nil {
 		t.Fatal("flush failed")
 	}
 
-	sess.SessionRelease(nil, w)
+	sess.SessionRelease(ctx, w)
 }
 
 func TestProvider_SessionInit(t *testing.T) {

--- a/server/web/session/session.go
+++ b/server/web/session/session.go
@@ -127,7 +127,7 @@ func NewManager(provideName string, cf *ManagerConfig) (*Manager, error) {
 		}
 	}
 
-	err := provider.SessionInit(nil, cf.Maxlifetime, cf.ProviderConfig)
+	err := provider.SessionInit(context.Background(), cf.Maxlifetime, cf.ProviderConfig)
 	if err != nil {
 		return nil, err
 	}
@@ -191,12 +191,12 @@ func (manager *Manager) SessionStart(w http.ResponseWriter, r *http.Request) (se
 	}
 
 	if sid != "" {
-		exists, err := manager.provider.SessionExist(nil, sid)
+		exists, err := manager.provider.SessionExist(context.Background(), sid)
 		if err != nil {
 			return nil, err
 		}
 		if exists {
-			return manager.provider.SessionRead(nil, sid)
+			return manager.provider.SessionRead(context.Background(), sid)
 		}
 	}
 
@@ -206,7 +206,7 @@ func (manager *Manager) SessionStart(w http.ResponseWriter, r *http.Request) (se
 		return nil, errs
 	}
 
-	session, err = manager.provider.SessionRead(nil, sid)
+	session, err = manager.provider.SessionRead(context.Background(), sid)
 	if err != nil {
 		return nil, err
 	}
@@ -249,7 +249,7 @@ func (manager *Manager) SessionDestroy(w http.ResponseWriter, r *http.Request) {
 	}
 
 	sid, _ := url.QueryUnescape(cookie.Value)
-	manager.provider.SessionDestroy(nil, sid)
+	manager.provider.SessionDestroy(context.Background(), sid)
 	if manager.config.EnableSetCookie {
 		expiration := time.Now()
 		cookie = &http.Cookie{
@@ -268,7 +268,7 @@ func (manager *Manager) SessionDestroy(w http.ResponseWriter, r *http.Request) {
 
 // GetSessionStore Get SessionStore by its id.
 func (manager *Manager) GetSessionStore(sid string) (sessions Store, err error) {
-	sessions, err = manager.provider.SessionRead(nil, sid)
+	sessions, err = manager.provider.SessionRead(context.Background(), sid)
 	return
 }
 
@@ -291,7 +291,7 @@ func (manager *Manager) SessionRegenerateID(w http.ResponseWriter, r *http.Reque
 	cookie, err := r.Cookie(manager.config.CookieName)
 	if err != nil || cookie.Value == "" {
 		// delete old cookie
-		session, err = manager.provider.SessionRead(nil, sid)
+		session, err = manager.provider.SessionRead(context.Background(), sid)
 		if err != nil {
 			return nil, err
 		}
@@ -310,7 +310,7 @@ func (manager *Manager) SessionRegenerateID(w http.ResponseWriter, r *http.Reque
 			return nil, err
 		}
 
-		session, err = manager.provider.SessionRegenerate(nil, oldsid, sid)
+		session, err = manager.provider.SessionRegenerate(context.Background(), oldsid, sid)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
updating to go-redis/v9, to support up to redis 7 (which f.ex. support new cluster modes, like announce-hostname)

some calls like `provider.SessionInit` pass `nil` as the context
 https://github.com/beego/beego/blob/219051dbc8cad7d92667dff7d69fb6e2f54c868b/server/web/session/session.go#L130

hence had to add some checks in f.ex. `sessions/redis/sess_redis.go` to initalize `ctx = context.Background()` if `ctx == nil`, as `ctx` is required by go-redis/v9

