### PR TITLE
use filepath.Join() to build file paths

### DIFF
--- a/client/httplib/httplib.go
+++ b/client/httplib/httplib.go
@@ -42,7 +42,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
-	"path"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -626,7 +626,7 @@ func (b *BeegoHTTPRequest) ToFile(filename string) error {
 
 // Check if the file directory exists. If it doesn't then it's created
 func pathExistAndMkdir(filename string) (err error) {
-	filename = path.Dir(filename)
+	filename = filepath.Dir(filename)
 	_, err = os.Stat(filename)
 	if err == nil {
 		return nil

--- a/core/logs/file.go
+++ b/core/logs/file.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"path"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -226,7 +225,7 @@ func (w *fileLogWriter) createLogFile() (*os.File, error) {
 		return nil, err
 	}
 
-	filepath := path.Dir(w.Filename)
+	filepath := filepath.Dir(w.Filename)
 	os.MkdirAll(filepath, os.FileMode(dirperm))
 
 	fd, err := os.OpenFile(w.Filename, os.O_WRONLY|os.O_APPEND|os.O_CREATE, os.FileMode(perm))

--- a/server/web/session/sess_file.go
+++ b/server/web/session/sess_file.go
@@ -21,7 +21,6 @@ import (
 	"io"
 	"net/http"
 	"os"
-	"path"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -88,16 +87,16 @@ func (fs *FileSessionStore) SessionRelease(ctx context.Context, w http.ResponseW
 		SLogger.Println(err)
 		return
 	}
-	_, err = os.Stat(path.Join(filepder.savePath, string(fs.sid[0]), string(fs.sid[1]), fs.sid))
+	_, err = os.Stat(filepath.Join(filepder.savePath, string(fs.sid[0]), string(fs.sid[1]), fs.sid))
 	var f *os.File
 	if err == nil {
-		f, err = os.OpenFile(path.Join(filepder.savePath, string(fs.sid[0]), string(fs.sid[1]), fs.sid), os.O_RDWR, 0o777)
+		f, err = os.OpenFile(filepath.Join(filepder.savePath, string(fs.sid[0]), string(fs.sid[1]), fs.sid), os.O_RDWR, 0o777)
 		if err != nil {
 			SLogger.Println(err)
 			return
 		}
 	} else if os.IsNotExist(err) {
-		f, err = os.Create(path.Join(filepder.savePath, string(fs.sid[0]), string(fs.sid[1]), fs.sid))
+		f, err = os.Create(filepath.Join(filepder.savePath, string(fs.sid[0]), string(fs.sid[1]), fs.sid))
 		if err != nil {
 			SLogger.Println(err)
 			return
@@ -195,7 +194,7 @@ func (fp *FileProvider) SessionExist(ctx context.Context, sid string) (bool, err
 		return false, errors.New("min length of session id is 2")
 	}
 
-	_, err := os.Stat(path.Join(fp.savePath, string(sid[0]), string(sid[1]), sid))
+	_, err := os.Stat(filepath.Join(fp.savePath, string(sid[0]), string(sid[1]), sid))
 	return err == nil, nil
 }
 
@@ -203,7 +202,7 @@ func (fp *FileProvider) SessionExist(ctx context.Context, sid string) (bool, err
 func (fp *FileProvider) SessionDestroy(ctx context.Context, sid string) error {
 	filepder.lock.Lock()
 	defer filepder.lock.Unlock()
-	os.Remove(path.Join(fp.savePath, string(sid[0]), string(sid[1]), sid))
+	os.Remove(filepath.Join(fp.savePath, string(sid[0]), string(sid[1]), sid))
 	return nil
 }
 
@@ -234,10 +233,10 @@ func (fp *FileProvider) SessionRegenerate(ctx context.Context, oldsid, sid strin
 	filepder.lock.Lock()
 	defer filepder.lock.Unlock()
 
-	oldPath := path.Join(fp.savePath, string(oldsid[0]), string(oldsid[1]))
-	oldSidFile := path.Join(oldPath, oldsid)
-	newPath := path.Join(fp.savePath, string(sid[0]), string(sid[1]))
-	newSidFile := path.Join(newPath, sid)
+	oldPath := filepath.Join(fp.savePath, string(oldsid[0]), string(oldsid[1]))
+	oldSidFile := filepath.Join(oldPath, oldsid)
+	newPath := filepath.Join(fp.savePath, string(sid[0]), string(sid[1]))
+	newSidFile := filepath.Join(newPath, sid)
 
 	// new sid file is exist
 	_, err := os.Stat(newSidFile)


### PR DESCRIPTION
According to https://pkg.go.dev/path,
> The path package should only be used for paths separated by forward slashes, such as the paths in URLs. This package does not deal with Windows paths with drive letters or backslashes; to manipulate operating system paths, use the [path/filepath](https://pkg.go.dev/path/filepath) package.

NOTE: I found this issue just statically scan code. I don't have Windows machine so I haven't reproduced real problem nor verify it's resolved...