### PR TITLE
Added support for `select` with `options` tag for `templatefun.RenderForm`

### DIFF
--- a/server/web/templatefunc.go
+++ b/server/web/templatefunc.go
@@ -26,6 +26,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/beego/beego/v2/core/logs"
 	"github.com/beego/beego/v2/server/web/context"
 )
 
@@ -290,10 +291,10 @@ func RenderForm(obj interface{}) template.HTML {
 	}
 	objT = objT.Elem()
 	objV = objV.Elem()
-
 	var raw []string
 	for i := 0; i < objT.NumField(); i++ {
 		fieldV := objV.Field(i)
+
 		if !fieldV.CanSet() || unKind[fieldV.Kind()] {
 			continue
 		}
@@ -327,6 +328,25 @@ func renderFormField(label, name, fType string, value interface{}, id string, cl
 
 	if isValidForInput(fType) {
 		return fmt.Sprintf(`%v<input%v%v name="%v" type="%v" value="%v"%v>`, label, id, class, name, fType, value, requiredString)
+	}
+
+	if fType == "select" {
+		valueStr, ok := value.(string)
+		if !ok {
+			logs.Error("for select value must comma separated string that are the options for select")
+			return ""
+		}
+
+		var selectBuilder strings.Builder
+		selectBuilder.WriteString(fmt.Sprintf(`%v<select%v%v name="%v"></br>`, label, id, class, name))
+
+		for _, option := range strings.Split(valueStr, ",") {
+			selectBuilder.WriteString(fmt.Sprintf(`  <option value="%v"> %v </option></br>`, option, option))
+		}
+
+		selectBuilder.WriteString(`</select></br>`)
+
+		return selectBuilder.String()
 	}
 
 	return fmt.Sprintf(`%v<%v%v%v name="%v"%v>%v</%v>`, label, fType, id, class, name, requiredString, value, fType)

--- a/server/web/templatefunc.go
+++ b/server/web/templatefunc.go
@@ -291,10 +291,10 @@ func RenderForm(obj interface{}) template.HTML {
 	}
 	objT = objT.Elem()
 	objV = objV.Elem()
+
 	var raw []string
 	for i := 0; i < objT.NumField(); i++ {
 		fieldV := objV.Field(i)
-
 		if !fieldV.CanSet() || unKind[fieldV.Kind()] {
 			continue
 		}
@@ -311,7 +311,8 @@ func RenderForm(obj interface{}) template.HTML {
 	return template.HTML(strings.Join(raw, "</br>"))
 }
 
-// renderFormField returns a string containing HTML of a single form field.
+// renderFormField returns a string containing HTML of a single form field. In case of select fType, it will retrun
+// select tag with options. Value for select fType must be comma separated string which are use are
 func renderFormField(label, name, fType string, value interface{}, id string, class string, required bool) string {
 	if id != "" {
 		id = " id=\"" + id + "\""

--- a/server/web/templatefunc.go
+++ b/server/web/templatefunc.go
@@ -345,7 +345,7 @@ func renderFormField(label, name, fType string, value interface{}, id string, cl
 			selectBuilder.WriteString(fmt.Sprintf(`  <option value="%v"> %v </option></br>`, option, option))
 		}
 
-		selectBuilder.WriteString(`</select></br>`)
+		selectBuilder.WriteString(`</select>`)
 
 		return selectBuilder.String()
 	}

--- a/server/web/templatefunc_test.go
+++ b/server/web/templatefunc_test.go
@@ -205,13 +205,13 @@ func TestRenderForm(t *testing.T) {
 		ID      int         `form:"-"`
 		Name    interface{} `form:"username"`
 		Age     int         `form:"age,text,年龄："`
-		Sex     string
+		Sex     string      `form:"sex,select"`
 		Email   []string
 		Intro   string `form:",textarea"`
 		Ignored string `form:"-"`
 	}
 
-	u := user{Name: "test", Intro: "Some Text"}
+	u := user{Name: "test", Intro: "Some Text", Sex: "Male,Female"}
 	output := RenderForm(u)
 	if output != template.HTML("") {
 		t.Errorf("output should be empty but got %v", output)
@@ -220,7 +220,10 @@ func TestRenderForm(t *testing.T) {
 	result := template.HTML(
 		`Name: <input name="username" type="text" value="test"></br>` +
 			`年龄：<input name="age" type="text" value="0"></br>` +
-			`Sex: <input name="Sex" type="text" value=""></br>` +
+			`Sex: <select name="sex"></br>` +
+			`  <option value="Male"> Male </option></br>` +
+			`  <option value="Female"> Female </option></br>` +
+			`</select></br>` +
 			`Intro: <textarea name="Intro">Some Text</textarea>`)
 	if output != result {
 		t.Errorf("output should equal `%v` but got `%v`", result, output)


### PR DESCRIPTION
Added support for `select` with `options` tag for `templatefun.RenderForm`

# Example
```go
type Vnf struct {
	id       int
	Name     string `form:"name" required:"true" class:"w-full h-4 sm:h-9 border-b-2 border-gray-300 focus:border-blue-300 outline-none"`
	PublicIp string `form:"publicIp" required:"true" class:"w-full h-4 sm:h-9 border-b-2 border-gray-300 focus:border-blue-300 outline-none"`
	Version  string `form:"version,select" required:"true" class:"w-full h-4 sm:h-9 border-b-2 border-gray-300 focus:border-blue-300 outline-none"`
	Flavor   string `form:"flavor" required:"true" class:"w-full h-4 sm:h-9 border-b-2 border-gray-300 focus:border-blue-300 outline-none"`
}

vnf := Vnf{Flavor: "small", Version: "v0.0.1,v0.0.2,v2.0.0"}
c.Data["Form"] = beego.RenderForm(&vnf)
```
<img width="514" alt="Screenshot 2024-08-07 at 7 11 24 PM" src="https://github.com/user-attachments/assets/59055c00-4808-40e8-a8bc-ffdfec4f1e18">

