### PR TITLE
add Enum string to validators

### DIFF
--- a/core/validation/README.md
+++ b/core/validation/README.md
@@ -140,6 +140,7 @@ Struct Tag Functions:
 	Tel
 	Phone
 	ZipCode
+    Enum
 
 ## LICENSE
 

--- a/core/validation/validation.go
+++ b/core/validation/validation.go
@@ -245,6 +245,11 @@ func (v *Validation) ZipCode(obj interface{}, key string) *Result {
 	return v.apply(ZipCode{Match{Regexp: zipCodePattern}, key}, obj)
 }
 
+// Enum Test that the obj is in the specified enumeration if type is string
+func (v *Validation) Enum(obj interface{}, vals string, key string) *Result {
+	return v.apply(Enum{vals, key}, obj)
+}
+
 func (v *Validation) apply(chk Validator, obj interface{}) *Result {
 	if nil == obj {
 		if chk.IsSatisfied(obj) {

--- a/core/validation/validation_test.go
+++ b/core/validation/validation_test.go
@@ -363,24 +363,16 @@ func TestZipCode(t *testing.T) {
 func TestEnum(t *testing.T) {
 	valid := Validation{}
 
-	if !valid.Enum("sms", "sms|email|code", "enum").Ok {
-		t.Error("\"sms\" is in the enum list of \"sms|email|code\" should be true")
+	if valid.Enum("sms_code", "sms|email|code", "enum").Ok {
+		t.Error("\"sms_code\" is in the enum list of \"sms|email|code\" should be false")
 	}
 
-	if valid.Enum("phone", "sms|code|email", "enum").Ok {
-		t.Error("\"phone\" is in the enum list of \"sms|code|email\" should be false")
+	if !valid.Enum("sms", "email|sms|code", "enum").Ok {
+		t.Error("\"sms\" is in the enum list of \"email|sms|code\" should be true")
 	}
 
-	if valid.Enum("", "email|sms|code", "enum").Ok {
-		t.Error("\"\" is in the enum list of \"email|sms|code\" should be false")
-	}
-
-	if valid.Enum("sms", "", "enum").Ok {
-		t.Error("\"sms\" is in the enum list of \"\" should be false")
-	}
-
-	if !valid.Enum("", "", "enum").Ok {
-		t.Error("\"\" is in the enum list of \"\" should be true")
+	if valid.Enum(200, "code|email|sms", "enum").Ok {
+		t.Error("200 is in the enum list of \"code|email|sms\" should be false")
 	}
 }
 

--- a/core/validation/validation_test.go
+++ b/core/validation/validation_test.go
@@ -360,6 +360,30 @@ func TestZipCode(t *testing.T) {
 	}
 }
 
+func TestEnum(t *testing.T) {
+	valid := Validation{}
+
+	if !valid.Enum("sms", "sms|email|code", "enum").Ok {
+		t.Error("\"sms\" is in the enum list of \"sms|email|code\" should be true")
+	}
+
+	if valid.Enum("phone", "sms|code|email", "enum").Ok {
+		t.Error("\"phone\" is in the enum list of \"sms|code|email\" should be false")
+	}
+
+	if valid.Enum("", "email|sms|code", "enum").Ok {
+		t.Error("\"\" is in the enum list of \"email|sms|code\" should be false")
+	}
+
+	if valid.Enum("sms", "", "enum").Ok {
+		t.Error("\"sms\" is in the enum list of \"\" should be false")
+	}
+
+	if !valid.Enum("", "", "enum").Ok {
+		t.Error("\"\" is in the enum list of \"\" should be true")
+	}
+}
+
 func TestValid(t *testing.T) {
 	type user struct {
 		ID   int

--- a/core/validation/validators.go
+++ b/core/validation/validators.go
@@ -58,7 +58,7 @@ var MessageTmpls = map[string]string{
 	"Tel":          "Must be valid telephone number",
 	"Phone":        "Must be valid telephone or mobile phone number",
 	"ZipCode":      "Must be valid zipcode",
-	"Enum":         "Must be in enum value and only support string",
+	"Enum":         "Must be a string value in \"%s\"",
 }
 
 var once sync.Once
@@ -760,8 +760,8 @@ func (e Enum) IsSatisfied(i interface{}) bool {
 }
 
 // DefaultMessage return the default Enum error message
-func (Enum) DefaultMessage() string {
-	return MessageTmpls["Enum"]
+func (e Enum) DefaultMessage() string {
+	return fmt.Sprintf(MessageTmpls["Enum"], e.Rules)
 }
 
 // GetKey return the e.Key

--- a/core/validation/validators.go
+++ b/core/validation/validators.go
@@ -58,6 +58,7 @@ var MessageTmpls = map[string]string{
 	"Tel":          "Must be valid telephone number",
 	"Phone":        "Must be valid telephone or mobile phone number",
 	"ZipCode":      "Must be valid zipcode",
+	"Enum":         "Must be in enum value and only support string",
 }
 
 var once sync.Once
@@ -736,5 +737,39 @@ func (z ZipCode) GetKey() string {
 
 // GetLimitValue return the limit value
 func (z ZipCode) GetLimitValue() interface{} {
+	return nil
+}
+
+// Enum Requires that the field must be within the enumerated value
+type Enum struct {
+	Rules string
+	Key   string
+}
+
+// IsSatisfied judge whether obj is valid
+func (e Enum) IsSatisfied(i interface{}) bool {
+	if val, ok := i.(string); ok {
+		roles := strings.Split(e.Rules, "|")
+		for _, v := range roles {
+			if val == strings.TrimSpace(v) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// DefaultMessage return the default Enum error message
+func (Enum) DefaultMessage() string {
+	return MessageTmpls["Enum"]
+}
+
+// GetKey return the e.Key
+func (e Enum) GetKey() string {
+	return e.Key
+}
+
+// GetLimitValue return nil now
+func (Enum) GetLimitValue() interface{} {
 	return nil
 }


### PR DESCRIPTION
#5695 
Because "," will be split, I use "|" to split.
And the number of parameters will be compared in parseFunc, so I accept the whole snippet with string.
example: `valid:"Enum(sms|email|code)"`