### PR TITLE
added BootStrap call in case where default db name is not used

### DIFF
--- a/client/orm/models_boot.go
+++ b/client/orm/models_boot.go
@@ -45,8 +45,13 @@ func RegisterModelWithSuffix(suffix string, models ...interface{}) {
 // BootStrap Bootstrap models.
 // make All model parsed and can not add more models
 func BootStrap() {
-	if dataBaseCache.getDefault() == nil {
-		fmt.Println("must have one Register DataBase alias named `default`")
+	BootStrapWithAlias("default")
+}
+
+// BootStrap with alias
+func BootStrapWithAlias(alias string) {
+	if _, ok := dataBaseCache.get(alias); !ok {
+		fmt.Printf("must have one Register DataBase alias named %q\n", alias)
 		debug.PrintStack()
 		return
 	}

--- a/client/orm/orm.go
+++ b/client/orm/orm.go
@@ -621,7 +621,6 @@ func (t *txOrm) RollbackUnlessCommit() error {
 
 // NewOrm create new orm
 func NewOrm() Ormer {
-	BootStrap() // execute only once
 	return NewOrmUsingDB(`default`)
 }
 
@@ -644,6 +643,8 @@ func NewOrmWithDB(driverName, aliasName string, db *sql.DB, params ...DBOption) 
 }
 
 func newDBWithAlias(al *alias) Ormer {
+	BootStrapWithAlias(al.Name) // execute only once
+
 	o := new(orm)
 	o.alias = al
 


### PR DESCRIPTION
In case where we are not using `default` database. We still need to call `BootStrap()` to init the models. Otherwise relations etc are not loaded. 