### PR TITLE
fixed #5573 ignore print to load conf/app.conf when not run web server

### DIFF
--- a/core/config/ini.go
+++ b/core/config/ini.go
@@ -19,7 +19,6 @@ import (
 	"bytes"
 	"context"
 	"errors"
-	"fmt"
 	"io"
 	"os"
 	"os/user"
@@ -30,6 +29,12 @@ import (
 
 	"github.com/mitchellh/mapstructure"
 )
+
+// InitDefaultGlobalInstanceErr cache default ini config init error
+// when it as cli or only import some mod and not run web server or manually specify the configuration file in the code
+// The current default load will print errors directly in the console resulting in an unfriendly display
+// Here the error will be saved and lazy loaded, displayed if and only when it is run web server
+var InitDefaultGlobalInstanceErr error
 
 var (
 	defaultSection = "default"   // default section means if some ini items not in a section, make them in default section,
@@ -518,7 +523,7 @@ func init() {
 
 	err := InitGlobalInstance("ini", "conf/app.conf")
 	if err != nil {
-		fmt.Fprint(os.Stderr, "init global config instance failed. If you do not use this, just ignore it. ", err)
+		InitDefaultGlobalInstanceErr = err
 	}
 }
 

--- a/server/web/beego.go
+++ b/server/web/beego.go
@@ -15,6 +15,8 @@
 package web
 
 import (
+	"fmt"
+	"github.com/beego/beego/v2/core/config"
 	"os"
 	"path/filepath"
 	"sync"
@@ -48,6 +50,13 @@ func AddAPPStartHook(hf ...hookfunc) {
 // beego.Run(":8089")
 // beego.Run("127.0.0.1:8089")
 func Run(params ...string) {
+
+	// lazy displayed init default config ini error
+	if config.InitDefaultGlobalInstanceErr != nil {
+		_, _ = fmt.Fprintln(os.Stderr, "init global config instance failed. If you do not use this, just ignore it. ", config.InitDefaultGlobalInstanceErr)
+		config.InitDefaultGlobalInstanceErr = nil
+	}
+
 	if len(params) > 0 && params[0] != "" {
 		BeeApp.Run(params[0])
 	} else {


### PR DESCRIPTION
Fix # 5573 , Although this problem was fixed to some extent in MR5538 by displaying it in STE, the content in STE will also be displayed at certain times, which will lead to some ambiguity in use.

For example, I quoted beego to open a command line tool. The web server will be enabled only when its startup command is server or agent. At other times, it will be used as a command line tool and registered in PATH and used anywhere in the system. At this time, the following will appear:

_The user executes a command in a folder in the system. The command is executed successfully and the content is displayed in the window. However, since there is no config file in the directory, the beego error will be printed in the first line._

_This will cause ambiguity in the user's use. Similarly, when the configuration file is placed in the etc directory and specified in the code, an error will still occur when it is started at other locations._

Therefore, the error is modified and cached this time, and it is only displayed when the web server is running.