### PR TITLE
parse int, uint using implementation specific size

### DIFF
--- a/client/orm/internal/utils/utils.go
+++ b/client/orm/internal/utils/utils.go
@@ -62,7 +62,7 @@ func (f StrTo) Float64() (float64, error) {
 
 // Int string to int
 func (f StrTo) Int() (int, error) {
-	v, err := strconv.ParseInt(f.String(), 10, 32)
+	v, err := strconv.ParseInt(f.String(), 10, strconv.IntSize)
 	return int(v), err
 }
 
@@ -100,7 +100,7 @@ func (f StrTo) Int64() (int64, error) {
 
 // Uint string to uint
 func (f StrTo) Uint() (uint, error) {
-	v, err := strconv.ParseUint(f.String(), 10, 32)
+	v, err := strconv.ParseUint(f.String(), 10, strconv.IntSize)
 	return uint(v), err
 }
 


### PR DESCRIPTION
The size of native int/unit is implementation specific. It is better not to assume it as 32 bit and use the actual implementation specific size to parse these types from strings. The `strconv.IntSize` constant is supposed to have the right value for the target platform and architecture.