### PR TITLE
fix issue 5732: `formValue` always ignore the empty value

### DIFF
--- a/client/cache/file_test.go
+++ b/client/cache/file_test.go
@@ -17,10 +17,11 @@ package cache
 import (
 	"context"
 	"fmt"
-	"github.com/stretchr/testify/assert"
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestFileCacheStartAndGC(t *testing.T) {

--- a/server/web/context/form.go
+++ b/server/web/context/form.go
@@ -50,8 +50,9 @@ func parseFormToStruct(form url.Values, objT reflect.Type, objV reflect.Value) e
 			continue
 		}
 
-		value, ok := formValue(tag, form, fieldT)
-		if !ok {
+		value, ok := formFirstValue(tag, form, fieldT)
+
+		if !ok && fieldT.Type.Kind() != reflect.Slice {
 			continue
 		}
 
@@ -168,11 +169,12 @@ func formTagName(fieldT reflect.StructField) (string, bool) {
 	return tag, true
 }
 
-func formValue(tag string, form url.Values, fieldT reflect.StructField) (string, bool) {
+func formFirstValue(tag string, form url.Values, fieldT reflect.StructField) (string, bool) {
 	formValues := form[tag]
 	if len(formValues) == 0 {
 		defaultValue := fieldT.Tag.Get("default")
 		return defaultValue, defaultValue != ""
 	}
-	return formValues[0], true
+	val := formValues[0]
+	return val, val != ""
 }

--- a/server/web/context/form_test.go
+++ b/server/web/context/form_test.go
@@ -22,7 +22,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestFormValue(t *testing.T) {
+func TestFormFirstValue(t *testing.T) {
 	typ := reflect.TypeOf(TestStruct{})
 	defField, _ := typ.FieldByName("DefaultField")
 	noDefField, _ := typ.FieldByName("NoDefaultField")
@@ -54,7 +54,17 @@ func TestFormValue(t *testing.T) {
 				"defaultField": {"", "bcd"},
 			},
 			wantRes: "",
-			wantOk:  true,
+			wantOk:  false,
+		},
+		{
+			name:  "empty default value",
+			tag:   "defaultField",
+			field: defField,
+			form: map[string][]string{
+				"defaultField": {"", "bcd"},
+			},
+			wantRes: "",
+			wantOk:  false,
 		},
 		{
 			name:    "use default value",
@@ -75,7 +85,7 @@ func TestFormValue(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			val, ok := formValue(tc.tag, tc.form, tc.field)
+			val, ok := formFirstValue(tc.tag, tc.form, tc.field)
 			assert.Equal(t, tc.wantRes, val)
 			assert.Equal(t, tc.wantOk, ok)
 		})

--- a/server/web/router.go
+++ b/server/web/router.go
@@ -15,8 +15,8 @@
 package web
 
 import (
-	"context"
 	"bytes"
+	"context"
 	"errors"
 	"fmt"
 	"io"


### PR DESCRIPTION
Closing #5732