### PR TITLE
fix: fix incorrect nil return value

### DIFF
--- a/test/bindata.go
+++ b/test/bindata.go
@@ -35,7 +35,7 @@ func bindataRead(data []byte, name string) ([]byte, error) {
 		return nil, fmt.Errorf("Read %q: %v", name, err)
 	}
 	if clErr != nil {
-		return nil, err
+		return nil, clErr
 	}
 
 	return buf.Bytes(), nil


### PR DESCRIPTION
Because err has been checked before and returned as != nil, err here must be nil, and `clErr ` should actually be returned