### PR TITLE
fix dbbase.GetColumns  expected 3 destination arguments but only query one in oracle

### DIFF
--- a/client/orm/db_oracle.go
+++ b/client/orm/db_oracle.go
@@ -87,7 +87,7 @@ func (d *dbBaseOracle) ShowTablesQuery() string {
 
 // Oracle
 func (d *dbBaseOracle) ShowColumnsQuery(table string) string {
-	return fmt.Sprintf("SELECT COLUMN_NAME FROM ALL_TAB_COLUMNS "+
+	return fmt.Sprintf("SELECT COLUMN_NAME, DATA_TYPE, NULLABLE FROM ALL_TAB_COLUMNS "+
 		"WHERE TABLE_NAME ='%s'", strings.ToUpper(table))
 }
 


### PR DESCRIPTION
fix dbbase.GetColumns  expected 3 destination arguments but only query one in oracle