### PR TITLE
fix: replace syscall.O_NOFOLLOW with utils.OpenFileSecure for Windows…

### DIFF
--- a/client/httplib/httplib.go
+++ b/client/httplib/httplib.go
@@ -36,6 +36,7 @@ import (
 	"crypto/tls"
 	"encoding/json"
 	"encoding/xml"
+	"github.com/beego/beego/v2/core/utils"
 	"io"
 	"mime/multipart"
 	"net"
@@ -44,7 +45,6 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"syscall"
 	"time"
 
 	"gopkg.in/yaml.v3"
@@ -616,7 +616,7 @@ func (b *BeegoHTTPRequest) ToFile(filename string) error {
 	if err != nil {
 		return err
 	}
-	f, err := os.OpenFile(filename, os.O_RDWR|os.O_CREATE|syscall.O_NOFOLLOW, 0600)
+	f, err := utils.OpenFileSecure(filename, os.O_RDWR|os.O_CREATE, 0600)
 	if err != nil {
 		return err
 	}

--- a/core/config/json/json.go
+++ b/core/config/json/json.go
@@ -18,14 +18,13 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"github.com/beego/beego/v2/core/utils"
+	"github.com/mitchellh/mapstructure"
 	"io"
 	"os"
 	"strconv"
 	"strings"
 	"sync"
-	"syscall"
-
-	"github.com/mitchellh/mapstructure"
 
 	"github.com/beego/beego/v2/core/config"
 	"github.com/beego/beego/v2/core/logs"
@@ -246,7 +245,7 @@ func (c *JSONConfigContainer) GetSection(section string) (map[string]string, err
 // SaveConfigFile save the config into file
 func (c *JSONConfigContainer) SaveConfigFile(filename string) (err error) {
 	// Write configuration file by filename.
-	f, err := os.OpenFile(filename, os.O_RDWR|os.O_CREATE|syscall.O_NOFOLLOW, 0600)
+	f, err := utils.OpenFileSecure(filename, os.O_RDWR|os.O_CREATE, 0600)
 	if err != nil {
 		return err
 	}

--- a/core/config/toml/toml.go
+++ b/core/config/toml/toml.go
@@ -15,11 +15,10 @@
 package toml
 
 import (
+	"github.com/beego/beego/v2/core/utils"
+	"github.com/pelletier/go-toml"
 	"os"
 	"strings"
-	"syscall"
-
-	"github.com/pelletier/go-toml"
 
 	"github.com/beego/beego/v2/core/config"
 )
@@ -308,7 +307,7 @@ func (c *configContainer) OnChange(key string, fn func(value string)) {
 // SaveConfigFile create or override the file
 func (c *configContainer) SaveConfigFile(filename string) error {
 	// Write configuration file by filename.
-	f, err := os.OpenFile(filename, os.O_RDWR|os.O_CREATE|syscall.O_NOFOLLOW, 0600)
+	f, err := utils.OpenFileSecure(filename, os.O_RDWR|os.O_CREATE, 0600)
 	if err != nil {
 		return err
 	}

--- a/core/config/xml/xml.go
+++ b/core/config/xml/xml.go
@@ -32,13 +32,12 @@ import (
 	"encoding/xml"
 	"errors"
 	"fmt"
+	"github.com/beego/beego/v2/core/utils"
+	"github.com/mitchellh/mapstructure"
 	"os"
 	"strconv"
 	"strings"
 	"sync"
-	"syscall"
-
-	"github.com/mitchellh/mapstructure"
 
 	"github.com/beego/x2j"
 
@@ -248,7 +247,7 @@ func (c *ConfigContainer) GetSection(section string) (map[string]string, error) 
 // SaveConfigFile save the config into file
 func (c *ConfigContainer) SaveConfigFile(filename string) (err error) {
 	// Write configuration file by filename.
-	f, err := os.OpenFile(filename, os.O_RDWR|os.O_CREATE|syscall.O_NOFOLLOW, 0600)
+	f, err := utils.OpenFileSecure(filename, os.O_RDWR|os.O_CREATE, 0600)
 	if err != nil {
 		return err
 	}

--- a/core/config/yaml/yaml.go
+++ b/core/config/yaml/yaml.go
@@ -26,12 +26,11 @@ package yaml
 import (
 	"errors"
 	"fmt"
+	"github.com/beego/beego/v2/core/utils"
+	"gopkg.in/yaml.v3"
 	"os"
 	"strings"
 	"sync"
-	"syscall"
-
-	"gopkg.in/yaml.v3"
 
 	"github.com/beego/beego/v2/core/config"
 	"github.com/beego/beego/v2/core/logs"
@@ -292,7 +291,7 @@ func (c *ConfigContainer) GetSection(section string) (map[string]string, error) 
 // SaveConfigFile save the config into file
 func (c *ConfigContainer) SaveConfigFile(filename string) (err error) {
 	// Write configuration file by filename.
-	f, err := os.OpenFile(filename, os.O_RDWR|os.O_CREATE|syscall.O_NOFOLLOW, 0600)
+	f, err := utils.OpenFileSecure(filename, os.O_RDWR|os.O_CREATE, 0600)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
![NO_FOLLOW](https://github.com/user-attachments/assets/db1b2635-4eaf-4a65-8df6-490d2b9d9a34)

[Pull request](https://github.com/beego/beego/pull/5764) fixed the NO_FOLLOW issue but there were still a few places we had it. Sample tests fails on windows
![NO_FOLLOW_WNDOWS_TEST](https://github.com/user-attachments/assets/281c6fc6-eaee-4e2a-83cf-7e85b3bed2d9)

Tests pass with fix 
![NO_FOLLOW_FIX](https://github.com/user-attachments/assets/c260bce9-2e98-4ffe-b866-9e956c19cf3c)

Beego v2.3.7, Windows 10, Toolchain go1.24.2 windows/amd64