### PR TITLE
The error log level should be info level since it is information that…

### DIFF
--- a/core/config/ini.go
+++ b/core/config/ini.go
@@ -520,7 +520,7 @@ func init() {
 
 	err := InitGlobalInstance("ini", "conf/app.conf")
 	if err != nil {
-		logs.Debug("init global config instance failed. If you do not use this, just ignore it. ", err)
+		logs.Info("init global config instance failed. If you do not use this, just ignore it. ", err)
 	}
 }
 


### PR DESCRIPTION
The error log level should be info level since it is information that is destined to be output.